### PR TITLE
Encode GET parameters + add a test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
         export CLARIFAI_API_KEY="$(python scripts/app_and_key_for_tests.py --create-key ${CLARIFAI_APP_ID})"
         python scripts/app_and_key_for_tests.py --create-workflow ${CLARIFAI_API_KEY}
         pip install pytest
-        pytest
+        pytest -v tests

--- a/clarifai_grpc/channel/clarifai_channel.py
+++ b/clarifai_grpc/channel/clarifai_channel.py
@@ -24,7 +24,6 @@ class ClarifaiChannel:
   @classmethod
   def get_json_channel(
       cls,
-      api_key=os.environ.get('CLARIFAI_API_KEY', 'no_key'),
       base_url=os.environ.get('CLARIFAI_API_BASE', 'https://api.clarifai.com')
   ):
     global wrap_response_deserializer
@@ -32,7 +31,7 @@ class ClarifaiChannel:
 
     session = cls._make_requests_session()
 
-    return GRPCJSONChannel(session=session, key=api_key, base_url=base_url)
+    return GRPCJSONChannel(session=session, base_url=base_url)
 
   @staticmethod
   def _make_requests_session():

--- a/clarifai_grpc/channel/errors.py
+++ b/clarifai_grpc/channel/errors.py
@@ -1,0 +1,6 @@
+class ApiError(Exception):
+    pass
+
+
+class UsageError(Exception):
+    pass

--- a/clarifai_grpc/channel/http_client.py
+++ b/clarifai_grpc/channel/http_client.py
@@ -8,7 +8,7 @@ import requests
 
 from clarifai_grpc.channel.errors import ApiError
 
-CLIENT_VERSION = '0.1.0'
+CLIENT_VERSION = '0.0.1'
 OS_VER = os.sys.platform
 PYTHON_VERSION = '.'.join(
     map(str, [os.sys.version_info.major, os.sys.version_info.minor, os.sys.version_info.micro]))

--- a/clarifai_grpc/channel/http_client.py
+++ b/clarifai_grpc/channel/http_client.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import typing  # noqa
-from pprint import pformat
 
 import requests
 
@@ -34,8 +33,8 @@ class HttpClient:
     }
     logger.debug("=" * 100)
     succinct_payload = self._mangle_base64_values(params)
-    logger.debug("%s %s\nHEADERS:\n%s\nPAYLOAD:\n%s", method, url, pformat(headers),
-                 pformat(succinct_payload))
+    logger.debug("%s %s\nHEADERS:\n%s\nPAYLOAD:\n%s", method, url, json.dumps(headers, indent=2),
+                 json.dumps(succinct_payload, indent=2))
     try:
       if method == 'GET':
         res = self._session.get(url, params=params, headers=headers)
@@ -55,11 +54,11 @@ class HttpClient:
       response_json = json.loads(res.content.decode('utf-8'))
     except ValueError:
       logger.exception("Could not get valid JSON from server response.")
-      logger.debug("\nRESULT:\n%s", pformat(res.content.decode('utf-8')))
+      logger.debug("\nRESULT:\n%s", json.dumps(res.text, indent=2))
       error = ApiError(url, params, method, res)
       raise error
     else:
-      logger.debug("\nRESULT:\n%s", pformat(response_json))
+      logger.debug("\nRESULT:\n%s", json.dumps(response_json, indent=2))
     if int(res.status_code / 100) != 2:
       error = ApiError(url, params, method, res)
       logger.warning("%s", str(error))

--- a/clarifai_grpc/channel/http_client.py
+++ b/clarifai_grpc/channel/http_client.py
@@ -7,10 +7,7 @@ from pprint import pformat
 
 import requests
 
-
-class ApiError(Exception):
-  pass
-
+from clarifai_grpc.channel.errors import ApiError
 
 CLIENT_VERSION = '0.1.0'
 OS_VER = os.sys.platform

--- a/clarifai_grpc/channel/http_client.py
+++ b/clarifai_grpc/channel/http_client.py
@@ -37,7 +37,7 @@ class HttpClient:
                  json.dumps(succinct_payload, indent=2))
     try:
       if method == 'GET':
-        res = self._session.get(url, params=params, headers=headers)
+        res = self._session.get(url, params=self._encode_get_params(params), headers=headers)
       elif method == "POST":
         res = self._session.post(url, data=json.dumps(params), headers=headers)
       elif method == "DELETE":
@@ -104,3 +104,22 @@ class HttpClient:
       return original_base64[:10] + '......' + original_base64[-10:]
     else:
       return original_base64
+
+  def _encode_get_params(self, params):
+    """
+    Encodes message params into format for use in GET args
+    """
+    encoded_params = {}
+    for (k, v) in params.items():
+      if isinstance(v, str):
+        encoded_params[k] = v
+      elif isinstance(v, bytes):
+        encoded_params[k] = v.decode("utf-8")
+      elif isinstance(v, (int, float, bool)):
+        encoded_params[k] = str(v)
+      elif isinstance(v, dict):
+        for (subk, subv) in self._encode_get_params(v).items():
+          encoded_params[k + '.' + subk] = subv
+      else:
+        raise TypeError('Cannot convert type for get params: %s' % type(v))
+    return encoded_params

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,6 @@
 import os
 import time
+import uuid
 
 from clarifai_grpc.channel.clarifai_channel import ClarifaiChannel
 from clarifai_grpc.grpc.api import service_pb2_grpc, service_pb2, resources_pb2
@@ -23,6 +24,14 @@ def test_post_patch_delete_input_on_json_channel():
 
 def test_post_patch_delete_input_on_grpc_channel():
   _assert_post_patch_delete_input(ClarifaiChannel.get_insecure_grpc_channel())
+
+
+def test_multiple_requests_on_json_channel():
+  _assert_multiple_requests(ClarifaiChannel.get_json_channel())
+
+
+def test_multiple_requests_on_grpc_channel():
+  _assert_multiple_requests(ClarifaiChannel.get_insecure_grpc_channel())
 
 
 def _assert_post_model_outputs(channel):
@@ -94,3 +103,173 @@ def _assert_post_patch_delete_input(channel):
     delete_request = service_pb2.DeleteInputRequest(input_id=input_id)
     delete_response = stub.DeleteInput(delete_request, metadata=metadata)
     assert status_code_pb2.SUCCESS == delete_response.status.code
+
+
+def _assert_multiple_requests(channel):
+  model_id = str(uuid.uuid4())
+
+  metadata = (('authorization', 'Key %s' % os.environ.get('CLARIFAI_API_KEY')),)
+  stub = service_pb2_grpc.V2Stub(channel)
+
+  _raise_on_failure(
+    stub.PostModels(
+      service_pb2.PostModelsRequest(
+        models=[
+          resources_pb2.Model(
+            id=model_id,
+            output_info=resources_pb2.OutputInfo(
+              data=resources_pb2.Data(
+                concepts=[
+                  resources_pb2.Concept(id="dog"),
+                  resources_pb2.Concept(id="toddler"),
+                ]
+              )
+            )
+          )
+        ]
+      ),
+      metadata=metadata)
+  )
+
+  post_inputs_response = stub.PostInputs(
+    service_pb2.PostInputsRequest(
+      inputs=[
+        resources_pb2.Input(
+          data=resources_pb2.Data(
+            image=resources_pb2.Image(
+              url="https://samples.clarifai.com/dog2.jpeg",
+              allow_duplicate_url=True
+            ),
+            concepts=[resources_pb2.Concept(id="dog")],
+          )
+        ),
+        resources_pb2.Input(
+          data=resources_pb2.Data(
+            image=resources_pb2.Image(
+              url="https://samples.clarifai.com/toddler-flowers.jpeg",
+              allow_duplicate_url=True
+            ),
+            concepts=[resources_pb2.Concept(id="toddler")],
+          )
+        ),
+      ]
+    ),
+    metadata=metadata
+  )
+  _raise_on_failure(post_inputs_response)
+
+  input_ids = [i.id for i in post_inputs_response.inputs]
+  _wait_for_inputs_upload(stub, metadata, input_ids)
+
+  response = stub.PostModelVersions(
+    service_pb2.PostModelVersionsRequest(model_id=model_id),
+    metadata=metadata
+  )
+  _raise_on_failure(response)
+
+  model_version_id = response.model.model_version.id
+  _wait_for_model_trained(stub, metadata, model_id, model_version_id)
+
+  _raise_on_failure(stub.PostModelVersionMetrics(
+    service_pb2.PostModelVersionMetricsRequest(
+      model_id=model_id,
+      version_id=model_version_id,
+    ),
+    metadata=metadata
+  ))
+
+  _wait_for_model_evaluated(stub, metadata, model_id, model_version_id)
+
+  response = stub.GetModelVersionMetrics(
+    service_pb2.GetModelVersionMetricsRequest(
+      model_id=model_id,
+      version_id=model_version_id,
+      fields=resources_pb2.FieldsValue(
+        confusion_matrix=True,
+        cooccurrence_matrix=True,
+        label_counts=True,
+        binary_metrics=True,
+        test_set=True,
+      )
+    ),
+    metadata=metadata
+  )
+  _raise_on_failure(response)
+
+  _raise_on_failure(
+    stub.DeleteModel(service_pb2.DeleteModelRequest(model_id=model_id), metadata=metadata)
+  )
+
+  _raise_on_failure(
+    stub.DeleteInputs(service_pb2.DeleteInputsRequest(ids=input_ids), metadata=metadata)
+  )
+
+
+def _wait_for_inputs_upload(stub, metadata, input_ids):
+  for input_id in input_ids:
+    while True:
+      get_input_response = stub.GetInput(
+        service_pb2.GetInputRequest(input_id=input_id),
+        metadata=metadata
+      )
+      _raise_on_failure(get_input_response)
+      if get_input_response.input.status.code == status_code_pb2.INPUT_DOWNLOAD_SUCCESS:
+        break
+      elif get_input_response.input.status.code in (status_code_pb2.INPUT_DOWNLOAD_PENDING,
+                                                    status_code_pb2.INPUT_DOWNLOAD_IN_PROGRESS):
+        time.sleep(1)
+        continue
+      else:
+        raise Exception(
+          get_input_response.status.description + " " + get_input_response.status.details
+        )
+  # At this point, all inputs have been downloaded successfully.
+
+
+def _wait_for_model_trained(stub, metadata, model_id, model_version_id):
+  while True:
+    response = stub.GetModelVersion(
+      service_pb2.GetModelVersionRequest(model_id=model_id, version_id=model_version_id),
+      metadata=metadata
+    )
+    _raise_on_failure(response)
+    if response.model_version.status.code == status_code_pb2.MODEL_TRAINED:
+      break
+    elif response.model_version.status.code in (status_code_pb2.MODEL_QUEUED_FOR_TRAINING,
+                                                status_code_pb2.MODEL_TRAINING):
+      time.sleep(1)
+      continue
+    else:
+      raise Exception(
+        response.status.description + " " + response.status.details
+      )
+  # At this point, the model has successfully finished training.
+
+
+def _wait_for_model_evaluated(stub, metadata, model_id, model_version_id):
+  while True:
+    response = stub.GetModelVersionMetrics(
+      service_pb2.GetModelVersionMetricsRequest(model_id=model_id, version_id=model_version_id),
+      metadata=metadata
+    )
+    _raise_on_failure(response)
+    if response.model_version.metrics.status.code == status_code_pb2.MODEL_EVALUATED:
+      break
+    elif response.model_version.metrics.status.code in (status_code_pb2.MODEL_QUEUED_FOR_EVALUATION,
+                                                        status_code_pb2.MODEL_EVALUATING):
+      time.sleep(1)
+      continue
+    else:
+      raise Exception(
+        response.status.description + " " + response.status.details
+      )
+  # At this point, the model has successfully finished evaluation.
+
+
+def _raise_on_failure(response):
+  if response.status.code != status_code_pb2.SUCCESS:
+    print("Received failure response:")
+    print(response)
+    raise Exception(
+      str(response.status.code) + " " + response.status.description + " " + response.status.details
+    )


### PR DESCRIPTION
This PR changes the GET parameter encoding, so it works on dictionary parameters, such as getting model version metrics with custom fields.

It also adds a large integration test that tests the above request + several others, to get a better confidence everything is integrated correctly.