### PR TITLE
Graceful failed response handling

### DIFF
--- a/clarifai_grpc/channel/http_client.py
+++ b/clarifai_grpc/channel/http_client.py
@@ -59,10 +59,6 @@ class HttpClient:
       raise error
     else:
       logger.debug("\nRESULT:\n%s", json.dumps(response_json, indent=2))
-    if int(res.status_code / 100) != 2:
-      error = ApiError(url, params, method, res)
-      logger.warning("%s", str(error))
-      raise error
     return response_json
 
   def _mangle_base64_values(self, params):  # type: (dict) -> dict

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -83,8 +83,7 @@ def _wait_for_model_evaluated(stub, metadata, model_id, model_version_id):
 
 def _raise_on_failure(response):
   if response.status.code != status_code_pb2.SUCCESS:
-    print("Received failure response:")
-    print(response)
+    message = str(response.status.code) + " " + response.status.description + " " + response.status.details
     raise Exception(
-      str(response.status.code) + " " + response.status.description + " " + response.status.details
+      f"Received failure response `{message}`. Whole response object: {response}"
     )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -34,8 +34,13 @@ def _wait_for_inputs_upload(stub, metadata, input_ids):
                                                     status_code_pb2.INPUT_DOWNLOAD_IN_PROGRESS):
         time.sleep(1)
       else:
+        error_message = (
+          str(get_input_response.status.code) + " " +
+          get_input_response.status.description + " " +
+          get_input_response.status.details
+        )
         raise Exception(
-          get_input_response.status.description + " " + get_input_response.status.details
+          f"Expected inputs to upload, but got {error_message}. Full response: {get_input_response}"
         )
   # At this point, all inputs have been downloaded successfully.
 
@@ -53,8 +58,13 @@ def _wait_for_model_trained(stub, metadata, model_id, model_version_id):
                                                 status_code_pb2.MODEL_TRAINING):
       time.sleep(1)
     else:
+      error_message = (
+        str(response.status.code) + " " +
+        response.status.description + " " +
+        response.status.details
+      )
       raise Exception(
-        response.status.description + " " + response.status.details
+        f"Expected model to train, but got {error_message}. Full response: {response}"
       )
   # At this point, the model has successfully finished training.
 
@@ -72,15 +82,24 @@ def _wait_for_model_evaluated(stub, metadata, model_id, model_version_id):
                                                         status_code_pb2.MODEL_EVALUATING):
       time.sleep(1)
     else:
+      error_message = (
+        str(response.status.code) + " " +
+        response.status.description + " " +
+        response.status.details
+      )
       raise Exception(
-        response.status.description + " " + response.status.details
+        f"Expected model to evaluate, but got {error_message}. Full response: {response}"
       )
   # At this point, the model has successfully finished evaluation.
 
 
 def _raise_on_failure(response):
   if response.status.code != status_code_pb2.SUCCESS:
-    message = str(response.status.code) + " " + response.status.description + " " + response.status.details
+    error_message = (
+      str(response.status.code) + " " +
+      response.status.description + " " +
+      response.status.details
+    )
     raise Exception(
-      f"Received failure response `{message}`. Whole response object: {response}"
+      f"Received failure response `{error_message}`. Whole response object: {response}"
     )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -33,7 +33,6 @@ def _wait_for_inputs_upload(stub, metadata, input_ids):
       elif get_input_response.input.status.code in (status_code_pb2.INPUT_DOWNLOAD_PENDING,
                                                     status_code_pb2.INPUT_DOWNLOAD_IN_PROGRESS):
         time.sleep(1)
-        continue
       else:
         raise Exception(
           get_input_response.status.description + " " + get_input_response.status.details
@@ -53,7 +52,6 @@ def _wait_for_model_trained(stub, metadata, model_id, model_version_id):
     elif response.model_version.status.code in (status_code_pb2.MODEL_QUEUED_FOR_TRAINING,
                                                 status_code_pb2.MODEL_TRAINING):
       time.sleep(1)
-      continue
     else:
       raise Exception(
         response.status.description + " " + response.status.details
@@ -73,7 +71,6 @@ def _wait_for_model_evaluated(stub, metadata, model_id, model_version_id):
     elif response.model_version.metrics.status.code in (status_code_pb2.MODEL_QUEUED_FOR_EVALUATION,
                                                         status_code_pb2.MODEL_EVALUATING):
       time.sleep(1)
-      continue
     else:
       raise Exception(
         response.status.description + " " + response.status.details

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,90 @@
+import time
+
+from clarifai_grpc.channel.clarifai_channel import ClarifaiChannel
+from clarifai_grpc.grpc.api import service_pb2
+from clarifai_grpc.grpc.api.status import status_code_pb2
+
+
+def both_channels(func):
+  """
+  A decorator that runs the test first using the gRPC channel and then using the JSON channel.
+  :param func: The test function.
+  :return: A function wrapper.
+  """
+  def func_wrapper():
+    channel = ClarifaiChannel.get_insecure_grpc_channel()
+    func(channel)
+
+    channel = ClarifaiChannel.get_json_channel()
+    func(channel)
+  return func_wrapper
+
+
+def _wait_for_inputs_upload(stub, metadata, input_ids):
+  for input_id in input_ids:
+    while True:
+      get_input_response = stub.GetInput(
+        service_pb2.GetInputRequest(input_id=input_id),
+        metadata=metadata
+      )
+      _raise_on_failure(get_input_response)
+      if get_input_response.input.status.code == status_code_pb2.INPUT_DOWNLOAD_SUCCESS:
+        break
+      elif get_input_response.input.status.code in (status_code_pb2.INPUT_DOWNLOAD_PENDING,
+                                                    status_code_pb2.INPUT_DOWNLOAD_IN_PROGRESS):
+        time.sleep(1)
+        continue
+      else:
+        raise Exception(
+          get_input_response.status.description + " " + get_input_response.status.details
+        )
+  # At this point, all inputs have been downloaded successfully.
+
+
+def _wait_for_model_trained(stub, metadata, model_id, model_version_id):
+  while True:
+    response = stub.GetModelVersion(
+      service_pb2.GetModelVersionRequest(model_id=model_id, version_id=model_version_id),
+      metadata=metadata
+    )
+    _raise_on_failure(response)
+    if response.model_version.status.code == status_code_pb2.MODEL_TRAINED:
+      break
+    elif response.model_version.status.code in (status_code_pb2.MODEL_QUEUED_FOR_TRAINING,
+                                                status_code_pb2.MODEL_TRAINING):
+      time.sleep(1)
+      continue
+    else:
+      raise Exception(
+        response.status.description + " " + response.status.details
+      )
+  # At this point, the model has successfully finished training.
+
+
+def _wait_for_model_evaluated(stub, metadata, model_id, model_version_id):
+  while True:
+    response = stub.GetModelVersionMetrics(
+      service_pb2.GetModelVersionMetricsRequest(model_id=model_id, version_id=model_version_id),
+      metadata=metadata
+    )
+    _raise_on_failure(response)
+    if response.model_version.metrics.status.code == status_code_pb2.MODEL_EVALUATED:
+      break
+    elif response.model_version.metrics.status.code in (status_code_pb2.MODEL_QUEUED_FOR_EVALUATION,
+                                                        status_code_pb2.MODEL_EVALUATING):
+      time.sleep(1)
+      continue
+    else:
+      raise Exception(
+        response.status.description + " " + response.status.details
+      )
+  # At this point, the model has successfully finished evaluation.
+
+
+def _raise_on_failure(response):
+  if response.status.code != status_code_pb2.SUCCESS:
+    print("Received failure response:")
+    print(response)
+    raise Exception(
+      str(response.status.code) + " " + response.status.description + " " + response.status.details
+    )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -128,8 +128,7 @@ def test_list_models_with_pagination(channel):
   stub = service_pb2_grpc.V2Stub(channel)
 
   response = stub.ListModels(service_pb2.ListModelsRequest(per_page=2), metadata=metadata)
-  if response.status.code != status_code_pb2.SUCCESS:
-    raise Exception(response.status.description + " " + response.status.details)
+  _raise_on_failure(response)
   assert len(response.models) == 2
 
   # We shouldn 't have 1000*500 number of models, so the result should be empty.
@@ -137,8 +136,7 @@ def test_list_models_with_pagination(channel):
     service_pb2.ListModelsRequest(page=1000, per_page=500),
     metadata=metadata
   )
-  if response.status.code != status_code_pb2.SUCCESS:
-    raise Exception(response.status.description + " " + response.status.details)
+  _raise_on_failure(response)
   assert len(response.models) == 0
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -70,8 +70,7 @@ def _assert_post_model_outputs(channel):
     ])
   response = stub.PostModelOutputs(request, metadata=metadata)
 
-  if response.status.code != status_code_pb2.SUCCESS:
-      raise Exception(response.status.description + " " + response.status.details)
+  _raise_on_failure(response)
 
   assert len(response.outputs[0].data.concepts) > 0
 
@@ -124,8 +123,7 @@ def _assert_post_patch_delete_input(channel):
   )
   post_response = stub.PostInputs(post_request, metadata=metadata)
 
-  if post_response.status.code != status_code_pb2.SUCCESS:
-      raise Exception(post_response.status.description + " " + post_response.status.details)
+  _raise_on_failure(post_response)
 
   input_id = post_response.inputs[0].id
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,6 +10,8 @@ DOG_IMAGE_URL = 'https://samples.clarifai.com/dog2.jpeg'
 TRUCK_IMAGE_URL = "https://s3.amazonaws.com/samples.clarifai.com/red-truck.png"
 NON_EXISTING_IMAGE_URL = "http://example.com/non-existing.jpg"
 
+metadata = (('authorization', 'Key %s' % os.environ.get('CLARIFAI_API_KEY')),)
+
 
 def test_post_model_outputs_on_json_channel():
   _assert_post_model_outputs(ClarifaiChannel.get_json_channel())
@@ -66,7 +68,6 @@ def _assert_post_model_outputs(channel):
     inputs=[
       resources_pb2.Input(data=resources_pb2.Data(image=resources_pb2.Image(url=DOG_IMAGE_URL)))
     ])
-  metadata = (('authorization', 'Key %s' % os.environ.get('CLARIFAI_API_KEY')),)
   response = stub.PostModelOutputs(request, metadata=metadata)
 
   if response.status.code != status_code_pb2.SUCCESS:
@@ -82,7 +83,6 @@ def _assert_failed_post_model_outputs(channel):
     inputs=[
       resources_pb2.Input(data=resources_pb2.Data(image=resources_pb2.Image(url=NON_EXISTING_IMAGE_URL)))
     ])
-  metadata = (('authorization', 'Key %s' % os.environ.get('CLARIFAI_API_KEY')),)
   response = stub.PostModelOutputs(request, metadata=metadata)
 
   assert response.status.code == status_code_pb2.FAILURE
@@ -99,7 +99,6 @@ def _assert_mixed_success_post_model_outputs(channel):
       resources_pb2.Input(data=resources_pb2.Data(image=resources_pb2.Image(url=DOG_IMAGE_URL))),
       resources_pb2.Input(data=resources_pb2.Data(image=resources_pb2.Image(url=NON_EXISTING_IMAGE_URL)))
     ])
-  metadata = (('authorization', 'Key %s' % os.environ.get('CLARIFAI_API_KEY')),)
   response = stub.PostModelOutputs(request, metadata=metadata)
 
   assert response.status.code == status_code_pb2.MIXED_STATUS
@@ -110,7 +109,6 @@ def _assert_mixed_success_post_model_outputs(channel):
 
 def _assert_post_patch_delete_input(channel):
   stub = service_pb2_grpc.V2Stub(channel)
-  metadata = (('authorization', 'Key %s' % os.environ.get('CLARIFAI_API_KEY')),)
 
   post_request = service_pb2.PostInputsRequest(
     inputs=[
@@ -165,7 +163,6 @@ def _assert_post_patch_delete_input(channel):
 
 def _assert_list_models_with_pagination(channel):
   stub = service_pb2_grpc.V2Stub(channel)
-  metadata = (('authorization', 'Key %s' % os.environ.get('CLARIFAI_API_KEY')),)
 
   response = stub.ListModels(service_pb2.ListModelsRequest(per_page=2), metadata=metadata)
   if response.status.code != status_code_pb2.SUCCESS:
@@ -185,7 +182,6 @@ def _assert_list_models_with_pagination(channel):
 def _assert_multiple_requests(channel):
   model_id = str(uuid.uuid4())
 
-  metadata = (('authorization', 'Key %s' % os.environ.get('CLARIFAI_API_KEY')),)
   stub = service_pb2_grpc.V2Stub(channel)
 
   _raise_on_failure(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,69 +2,26 @@ import os
 import time
 import uuid
 
-from clarifai_grpc.channel.clarifai_channel import ClarifaiChannel
 from clarifai_grpc.grpc.api import service_pb2_grpc, service_pb2, resources_pb2
 from clarifai_grpc.grpc.api.status import status_code_pb2
+from tests.helpers import (both_channels, _raise_on_failure, _wait_for_inputs_upload,
+                           _wait_for_model_trained, _wait_for_model_evaluated)
+
 
 DOG_IMAGE_URL = 'https://samples.clarifai.com/dog2.jpeg'
 TRUCK_IMAGE_URL = "https://s3.amazonaws.com/samples.clarifai.com/red-truck.png"
 NON_EXISTING_IMAGE_URL = "http://example.com/non-existing.jpg"
 
+GENERAL_MODEL_ID = 'aaa03c23b3724a16a56b629203edc62c'
+
 metadata = (('authorization', 'Key %s' % os.environ.get('CLARIFAI_API_KEY')),)
 
 
-def test_post_model_outputs_on_json_channel():
-  _assert_post_model_outputs(ClarifaiChannel.get_json_channel())
-
-
-def test_post_model_outputs_on_grpc_channel():
-  _assert_post_model_outputs(ClarifaiChannel.get_insecure_grpc_channel())
-
-
-def test_failed_post_model_outputs_on_json_channel():
-  _assert_failed_post_model_outputs(ClarifaiChannel.get_json_channel())
-
-
-def test_failed_post_model_outputs_on_grpc_channel():
-  _assert_failed_post_model_outputs(ClarifaiChannel.get_insecure_grpc_channel())
-
-
-def test_mixed_success_post_model_outputs_on_json_channel():
-  _assert_mixed_success_post_model_outputs(ClarifaiChannel.get_json_channel())
-
-
-def test_mixed_success_post_model_outputs_on_grpc_channel():
-  _assert_mixed_success_post_model_outputs(ClarifaiChannel.get_insecure_grpc_channel())
-
-
-def test_post_patch_delete_input_on_json_channel():
-  _assert_post_patch_delete_input(ClarifaiChannel.get_json_channel())
-
-
-def test_post_patch_delete_input_on_grpc_channel():
-  _assert_post_patch_delete_input(ClarifaiChannel.get_insecure_grpc_channel())
-
-
-def test_list_models_with_pagination_on_json_channel():
-  _assert_list_models_with_pagination(ClarifaiChannel.get_json_channel())
-
-
-def test_list_models_with_pagination_on_grpc_channel():
-  _assert_list_models_with_pagination(ClarifaiChannel.get_insecure_grpc_channel())
-
-
-def test_multiple_requests_on_json_channel():
-  _assert_multiple_requests(ClarifaiChannel.get_json_channel())
-
-
-def test_multiple_requests_on_grpc_channel():
-  _assert_multiple_requests(ClarifaiChannel.get_insecure_grpc_channel())
-
-
-def _assert_post_model_outputs(channel):
+@both_channels
+def test_post_model_outputs(channel):
   stub = service_pb2_grpc.V2Stub(channel)
   request = service_pb2.PostModelOutputsRequest(
-    model_id='aaa03c23b3724a16a56b629203edc62c',
+    model_id=GENERAL_MODEL_ID,
     inputs=[
       resources_pb2.Input(data=resources_pb2.Data(image=resources_pb2.Image(url=DOG_IMAGE_URL)))
     ])
@@ -75,12 +32,15 @@ def _assert_post_model_outputs(channel):
   assert len(response.outputs[0].data.concepts) > 0
 
 
-def _assert_failed_post_model_outputs(channel):
+@both_channels
+def test_failed_post_model_outputs(channel):
   stub = service_pb2_grpc.V2Stub(channel)
   request = service_pb2.PostModelOutputsRequest(
-    model_id='aaa03c23b3724a16a56b629203edc62c',
+    model_id=GENERAL_MODEL_ID,
     inputs=[
-      resources_pb2.Input(data=resources_pb2.Data(image=resources_pb2.Image(url=NON_EXISTING_IMAGE_URL)))
+      resources_pb2.Input(
+        data=resources_pb2.Data(image=resources_pb2.Image(url=NON_EXISTING_IMAGE_URL))
+      )
     ])
   response = stub.PostModelOutputs(request, metadata=metadata)
 
@@ -90,13 +50,16 @@ def _assert_failed_post_model_outputs(channel):
   assert response.outputs[0].status.code == status_code_pb2.INPUT_DOWNLOAD_FAILED
 
 
-def _assert_mixed_success_post_model_outputs(channel):
+@both_channels
+def test_mixed_success_post_model_outputs(channel):
   stub = service_pb2_grpc.V2Stub(channel)
   request = service_pb2.PostModelOutputsRequest(
-    model_id='aaa03c23b3724a16a56b629203edc62c',
+    model_id=GENERAL_MODEL_ID,
     inputs=[
       resources_pb2.Input(data=resources_pb2.Data(image=resources_pb2.Image(url=DOG_IMAGE_URL))),
-      resources_pb2.Input(data=resources_pb2.Data(image=resources_pb2.Image(url=NON_EXISTING_IMAGE_URL)))
+      resources_pb2.Input(
+        data=resources_pb2.Data(image=resources_pb2.Image(url=NON_EXISTING_IMAGE_URL))
+      )
     ])
   response = stub.PostModelOutputs(request, metadata=metadata)
 
@@ -106,7 +69,8 @@ def _assert_mixed_success_post_model_outputs(channel):
   assert response.outputs[1].status.code == status_code_pb2.INPUT_DOWNLOAD_FAILED
 
 
-def _assert_post_patch_delete_input(channel):
+@both_channels
+def test_post_patch_delete_input(channel):
   stub = service_pb2_grpc.V2Stub(channel)
 
   post_request = service_pb2.PostInputsRequest(
@@ -135,8 +99,8 @@ def _assert_post_patch_delete_input(channel):
       if status_code == status_code_pb2.INPUT_DOWNLOAD_SUCCESS:
         break
       elif status_code not in (
-          status_code_pb2.INPUT_DOWNLOAD_PENDING,
-          status_code_pb2.INPUT_DOWNLOAD_IN_PROGRESS
+        status_code_pb2.INPUT_DOWNLOAD_PENDING,
+        status_code_pb2.INPUT_DOWNLOAD_IN_PROGRESS
       ):
         raise Exception(
           f'Waiting for input ID {input_id} failed, status code is {status_code}.')
@@ -159,7 +123,8 @@ def _assert_post_patch_delete_input(channel):
     assert status_code_pb2.SUCCESS == delete_response.status.code
 
 
-def _assert_list_models_with_pagination(channel):
+@both_channels
+def test_list_models_with_pagination(channel):
   stub = service_pb2_grpc.V2Stub(channel)
 
   response = stub.ListModels(service_pb2.ListModelsRequest(per_page=2), metadata=metadata)
@@ -177,7 +142,8 @@ def _assert_list_models_with_pagination(channel):
   assert len(response.models) == 0
 
 
-def _assert_multiple_requests(channel):
+@both_channels
+def test_model_creation_training_and_evaluation(channel):
   model_id = str(uuid.uuid4())
 
   stub = service_pb2_grpc.V2Stub(channel)
@@ -274,73 +240,3 @@ def _assert_multiple_requests(channel):
   _raise_on_failure(
     stub.DeleteInputs(service_pb2.DeleteInputsRequest(ids=input_ids), metadata=metadata)
   )
-
-
-def _wait_for_inputs_upload(stub, metadata, input_ids):
-  for input_id in input_ids:
-    while True:
-      get_input_response = stub.GetInput(
-        service_pb2.GetInputRequest(input_id=input_id),
-        metadata=metadata
-      )
-      _raise_on_failure(get_input_response)
-      if get_input_response.input.status.code == status_code_pb2.INPUT_DOWNLOAD_SUCCESS:
-        break
-      elif get_input_response.input.status.code in (status_code_pb2.INPUT_DOWNLOAD_PENDING,
-                                                    status_code_pb2.INPUT_DOWNLOAD_IN_PROGRESS):
-        time.sleep(1)
-        continue
-      else:
-        raise Exception(
-          get_input_response.status.description + " " + get_input_response.status.details
-        )
-  # At this point, all inputs have been downloaded successfully.
-
-
-def _wait_for_model_trained(stub, metadata, model_id, model_version_id):
-  while True:
-    response = stub.GetModelVersion(
-      service_pb2.GetModelVersionRequest(model_id=model_id, version_id=model_version_id),
-      metadata=metadata
-    )
-    _raise_on_failure(response)
-    if response.model_version.status.code == status_code_pb2.MODEL_TRAINED:
-      break
-    elif response.model_version.status.code in (status_code_pb2.MODEL_QUEUED_FOR_TRAINING,
-                                                status_code_pb2.MODEL_TRAINING):
-      time.sleep(1)
-      continue
-    else:
-      raise Exception(
-        response.status.description + " " + response.status.details
-      )
-  # At this point, the model has successfully finished training.
-
-
-def _wait_for_model_evaluated(stub, metadata, model_id, model_version_id):
-  while True:
-    response = stub.GetModelVersionMetrics(
-      service_pb2.GetModelVersionMetricsRequest(model_id=model_id, version_id=model_version_id),
-      metadata=metadata
-    )
-    _raise_on_failure(response)
-    if response.model_version.metrics.status.code == status_code_pb2.MODEL_EVALUATED:
-      break
-    elif response.model_version.metrics.status.code in (status_code_pb2.MODEL_QUEUED_FOR_EVALUATION,
-                                                        status_code_pb2.MODEL_EVALUATING):
-      time.sleep(1)
-      continue
-    else:
-      raise Exception(
-        response.status.description + " " + response.status.details
-      )
-  # At this point, the model has successfully finished evaluation.
-
-
-def _raise_on_failure(response):
-  if response.status.code != status_code_pb2.SUCCESS:
-    print("Received failure response:")
-    print(response)
-    raise Exception(
-      str(response.status.code) + " " + response.status.description + " " + response.status.details
-    )


### PR DESCRIPTION
This PR makes the failed or mixed response in a JSON channel to be handled in the same way as in the gRPC channel.

It also improves tests' structure.

Closes #4 .