### PR TITLE
Changed both the insecure and secure grpc channel creation to use the…

### DIFF
--- a/clarifai_grpc/channel/clarifai_channel.py
+++ b/clarifai_grpc/channel/clarifai_channel.py
@@ -47,7 +47,7 @@ class ClarifaiChannel:
   def get_grpc_channel():
     global wrap_response_deserializer
     wrap_response_deserializer = _response_deserializer_for_grpc
-    channel_address = "{}:18081".format(os.environ.get('CLARIFAI_GRPC_BASE', 'api-grpc.clarifai.com/'))
+    channel_address = "{}:18081".format(os.environ.get('CLARIFAI_GRPC_BASE', 'api-grpc.clarifai.com'))
 
     return service_pb2_grpc.grpc.secure_channel(
       channel_address,
@@ -58,6 +58,6 @@ class ClarifaiChannel:
   def get_insecure_grpc_channel():
     global wrap_response_deserializer
     wrap_response_deserializer = _response_deserializer_for_grpc
-    channel_address = "{}:18080".format(os.environ.get('CLARIFAI_GRPC_BASE', 'api-grpc.clarifai.com/'))
+    channel_address = "{}:18080".format(os.environ.get('CLARIFAI_GRPC_BASE', 'api-grpc.clarifai.com'))
 
     return service_pb2_grpc.grpc.insecure_channel(channel_address)

--- a/clarifai_grpc/channel/clarifai_channel.py
+++ b/clarifai_grpc/channel/clarifai_channel.py
@@ -47,7 +47,7 @@ class ClarifaiChannel:
   def get_grpc_channel():
     global wrap_response_deserializer
     wrap_response_deserializer = _response_deserializer_for_grpc
-    channel_address = "{}:18081".format(os.environ.get('CLARIFAI_GRPC_BASE', 'http://api-grpc.clarifai.com/'))
+    channel_address = "{}:18081".format(os.environ.get('CLARIFAI_GRPC_BASE', 'api-grpc.clarifai.com/'))
 
     return service_pb2_grpc.grpc.secure_channel(
       channel_address,
@@ -58,6 +58,6 @@ class ClarifaiChannel:
   def get_insecure_grpc_channel():
     global wrap_response_deserializer
     wrap_response_deserializer = _response_deserializer_for_grpc
-    channel_address = "{}:18080".format(os.environ.get('CLARIFAI_GRPC_BASE', 'http://api-grpc.clarifai.com/'))
+    channel_address = "{}:18080".format(os.environ.get('CLARIFAI_GRPC_BASE', 'api-grpc.clarifai.com/'))
 
     return service_pb2_grpc.grpc.insecure_channel(channel_address)

--- a/clarifai_grpc/channel/clarifai_channel.py
+++ b/clarifai_grpc/channel/clarifai_channel.py
@@ -47,9 +47,10 @@ class ClarifaiChannel:
   def get_grpc_channel():
     global wrap_response_deserializer
     wrap_response_deserializer = _response_deserializer_for_grpc
+    channel_address = "{}:18081".format(os.environ.get('CLARIFAI_GRPC_BASE', 'http://api-grpc.clarifai.com/'))
 
     return service_pb2_grpc.grpc.secure_channel(
-      'api-grpc.clarifai.com:18081',
+      channel_address,
       service_pb2_grpc.grpc.ssl_channel_credentials()
     )
 
@@ -57,5 +58,6 @@ class ClarifaiChannel:
   def get_insecure_grpc_channel():
     global wrap_response_deserializer
     wrap_response_deserializer = _response_deserializer_for_grpc
+    channel_address = "{}:18080".format(os.environ.get('CLARIFAI_GRPC_BASE', 'http://api-grpc.clarifai.com/'))
 
-    return service_pb2_grpc.grpc.insecure_channel('api-grpc.clarifai.com:18080')
+    return service_pb2_grpc.grpc.insecure_channel(channel_address)


### PR DESCRIPTION
Sets both the insecure and secure gRPC channels with the CLARIFAI_GRPC_BASE environment variable or http://api-grpc.clarifai.com by default if none is set.  Supports on-prem users.

Closes #8 