### PR TITLE
Retry PostModelOutputs on non-prod when the response is 504

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -189,5 +189,4 @@ def _retry_on_504_on_non_prod(func):
                 raise e
 
             print(f"Received 504, doing retry #{i}")
-            time.sleep(2 ** (i - 1))
     return response

--- a/tests/common.py
+++ b/tests/common.py
@@ -161,7 +161,7 @@ def raise_on_failure(response, custom_message=""):
         )
 
 
-def post_model_outputs_with_retries(
+def post_model_outputs_and_maybe_allow_retries(
     stub: service_pb2_grpc.V2Stub, request: service_pb2.PostModelOutputsRequest, metadata: Tuple
 ):
     return _retry_on_504_on_non_prod(lambda: stub.PostModelOutputs(request, metadata=metadata))

--- a/tests/test_deep_training.py
+++ b/tests/test_deep_training.py
@@ -9,7 +9,6 @@ from tests.common import (
     raise_on_failure,
     wait_for_inputs_upload,
     wait_for_model_trained,
-    _retry_on_504_on_non_prod,
     post_model_outputs_with_retries,
 )
 

--- a/tests/test_deep_training.py
+++ b/tests/test_deep_training.py
@@ -9,7 +9,7 @@ from tests.common import (
     raise_on_failure,
     wait_for_inputs_upload,
     wait_for_model_trained,
-    post_model_outputs_with_retries,
+    post_model_outputs_and_maybe_allow_retries,
 )
 
 URLS = [
@@ -182,7 +182,7 @@ def test_deep_classification_training_with_queries():
         ],
     )
 
-    post_model_outputs_response = post_model_outputs_with_retries(
+    post_model_outputs_response = post_model_outputs_and_maybe_allow_retries(
         stub, post_model_outputs_request, metadata=api_key_metadata(api_key)
     )
     raise_on_failure(post_model_outputs_response)

--- a/tests/test_image_predict.py
+++ b/tests/test_image_predict.py
@@ -8,6 +8,7 @@ from tests.common import (
     both_channels,
     metadata,
     raise_on_failure,
+    post_model_outputs_with_retries,
 )
 
 
@@ -23,7 +24,7 @@ def test_predict_image_url(channel):
             )
         ],
     )
-    response = stub.PostModelOutputs(request, metadata=metadata())
+    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
     raise_on_failure(response)
 
     assert len(response.outputs[0].data.concepts) > 0
@@ -50,7 +51,7 @@ def test_predict_image_url_with_max_concepts(channel):
             )
         ),
     )
-    response = stub.PostModelOutputs(request, metadata=metadata())
+    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
     raise_on_failure(response)
 
     assert len(response.outputs[0].data.concepts) == 3
@@ -77,7 +78,7 @@ def test_predict_image_url_with_min_value(channel):
             )
         ),
     )
-    response = stub.PostModelOutputs(request, metadata=metadata())
+    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
     raise_on_failure(response)
 
     assert len(response.outputs[0].data.concepts) > 0
@@ -111,7 +112,7 @@ def test_predict_image_url_with_selected_concepts(channel):
             )
         ),
     )
-    response = stub.PostModelOutputs(request, metadata=metadata())
+    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
     raise_on_failure(response)
 
     concepts = response.outputs[0].data.concepts
@@ -136,7 +137,7 @@ def test_predict_image_bytes(channel):
             )
         ],
     )
-    response = stub.PostModelOutputs(request, metadata=metadata())
+    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
 
     raise_on_failure(response)
 
@@ -154,7 +155,7 @@ def test_failed_predict(channel):
             )
         ],
     )
-    response = stub.PostModelOutputs(request, metadata=metadata())
+    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
 
     assert response.status.code == status_code_pb2.FAILURE
     assert response.status.description == "Failure"
@@ -176,7 +177,7 @@ def test_mixed_success_predict(channel):
             ),
         ],
     )
-    response = stub.PostModelOutputs(request, metadata=metadata())
+    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
 
     assert response.status.code == status_code_pb2.MIXED_STATUS
 

--- a/tests/test_image_predict.py
+++ b/tests/test_image_predict.py
@@ -8,7 +8,7 @@ from tests.common import (
     both_channels,
     metadata,
     raise_on_failure,
-    post_model_outputs_with_retries,
+    post_model_outputs_and_maybe_allow_retries,
 )
 
 
@@ -24,7 +24,7 @@ def test_predict_image_url(channel):
             )
         ],
     )
-    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
+    response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
     raise_on_failure(response)
 
     assert len(response.outputs[0].data.concepts) > 0
@@ -51,7 +51,7 @@ def test_predict_image_url_with_max_concepts(channel):
             )
         ),
     )
-    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
+    response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
     raise_on_failure(response)
 
     assert len(response.outputs[0].data.concepts) == 3
@@ -78,7 +78,7 @@ def test_predict_image_url_with_min_value(channel):
             )
         ),
     )
-    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
+    response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
     raise_on_failure(response)
 
     assert len(response.outputs[0].data.concepts) > 0
@@ -112,7 +112,7 @@ def test_predict_image_url_with_selected_concepts(channel):
             )
         ),
     )
-    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
+    response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
     raise_on_failure(response)
 
     concepts = response.outputs[0].data.concepts
@@ -137,7 +137,7 @@ def test_predict_image_bytes(channel):
             )
         ],
     )
-    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
+    response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
 
     raise_on_failure(response)
 
@@ -155,7 +155,7 @@ def test_failed_predict(channel):
             )
         ],
     )
-    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
+    response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
 
     assert response.status.code == status_code_pb2.FAILURE
     assert response.status.description == "Failure"
@@ -177,7 +177,7 @@ def test_mixed_success_predict(channel):
             ),
         ],
     )
-    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
+    response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
 
     assert response.status.code == status_code_pb2.MIXED_STATUS
 

--- a/tests/test_public_models_predicts.py
+++ b/tests/test_public_models_predicts.py
@@ -19,7 +19,7 @@ from tests.common import (
     metadata,
     raise_on_failure,
     BEER_VIDEO_URL,
-    post_model_outputs_with_retries,
+    post_model_outputs_and_maybe_allow_retries,
 )
 
 
@@ -54,7 +54,7 @@ def test_image_predict_on_public_models(channel):
                 )
             ],
         )
-        response = post_model_outputs_with_retries(stub, request, metadata=metadata())
+        response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
         raise_on_failure(
             response,
             custom_message=f"Image predict failed for the {title} model (ID: {model_id}).",
@@ -80,7 +80,7 @@ def test_video_predict_on_public_models(channel):
                 )
             ],
         )
-        response = post_model_outputs_with_retries(stub, request, metadata=metadata())
+        response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
         raise_on_failure(
             response,
             custom_message=f"Video predict failed for the {title} model (ID: {model_id}).",

--- a/tests/test_public_models_predicts.py
+++ b/tests/test_public_models_predicts.py
@@ -3,7 +3,6 @@ from tests.common import (
     DOG_IMAGE_URL,
     APPAREL_MODEL_ID,
     COLOR_MODEL_ID,
-    DEMOGRAPHICS_MODEL_ID,
     FACE_MODEL_ID,
     FOOD_MODEL_ID,
     GENERAL_EMBEDDING_MODEL_ID,
@@ -20,6 +19,7 @@ from tests.common import (
     metadata,
     raise_on_failure,
     BEER_VIDEO_URL,
+    post_model_outputs_with_retries,
 )
 
 
@@ -54,7 +54,7 @@ def test_image_predict_on_public_models(channel):
                 )
             ],
         )
-        response = stub.PostModelOutputs(request, metadata=metadata())
+        response = post_model_outputs_with_retries(stub, request, metadata=metadata())
         raise_on_failure(
             response,
             custom_message=f"Image predict failed for the {title} model (ID: {model_id}).",
@@ -80,7 +80,7 @@ def test_video_predict_on_public_models(channel):
                 )
             ],
         )
-        response = stub.PostModelOutputs(request, metadata=metadata())
+        response = post_model_outputs_with_retries(stub, request, metadata=metadata())
         raise_on_failure(
             response,
             custom_message=f"Video predict failed for the {title} model (ID: {model_id}).",

--- a/tests/test_video_predict.py
+++ b/tests/test_video_predict.py
@@ -7,7 +7,7 @@ from tests.common import (
     metadata,
     raise_on_failure,
     BEER_VIDEO_URL,
-    post_model_outputs_with_retries,
+    post_model_outputs_and_maybe_allow_retries,
 )
 
 
@@ -23,7 +23,7 @@ def test_predict_video_url(channel):
             )
         ],
     )
-    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
+    response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
     raise_on_failure(response)
 
     assert len(response.outputs[0].data.frames) > 0
@@ -48,7 +48,7 @@ def test_predict_video_url_with_min_value(channel):
             )
         ),
     )
-    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
+    response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
     raise_on_failure(response)
 
     assert len(response.outputs[0].data.frames) > 0
@@ -75,7 +75,7 @@ def test_predict_video_url_with_max_concepts(channel):
             )
         ),
     )
-    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
+    response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
     raise_on_failure(response)
 
     assert len(response.outputs[0].data.frames) > 0
@@ -100,7 +100,7 @@ def test_predict_video_url_with_custom_sample_ms(channel):
             )
         ),
     )
-    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
+    response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
     raise_on_failure(response)
 
     # The expected time per frame is the middle between the start and the end of the frame
@@ -128,7 +128,7 @@ def test_predict_video_bytes(channel):
             )
         ],
     )
-    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
+    response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
     raise_on_failure(response)
 
     assert len(response.outputs[0].data.frames) > 0

--- a/tests/test_video_predict.py
+++ b/tests/test_video_predict.py
@@ -7,6 +7,7 @@ from tests.common import (
     metadata,
     raise_on_failure,
     BEER_VIDEO_URL,
+    post_model_outputs_with_retries,
 )
 
 
@@ -22,7 +23,7 @@ def test_predict_video_url(channel):
             )
         ],
     )
-    response = stub.PostModelOutputs(request, metadata=metadata())
+    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
     raise_on_failure(response)
 
     assert len(response.outputs[0].data.frames) > 0
@@ -47,7 +48,7 @@ def test_predict_video_url_with_min_value(channel):
             )
         ),
     )
-    response = stub.PostModelOutputs(request, metadata=metadata())
+    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
     raise_on_failure(response)
 
     assert len(response.outputs[0].data.frames) > 0
@@ -74,7 +75,7 @@ def test_predict_video_url_with_max_concepts(channel):
             )
         ),
     )
-    response = stub.PostModelOutputs(request, metadata=metadata())
+    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
     raise_on_failure(response)
 
     assert len(response.outputs[0].data.frames) > 0
@@ -99,7 +100,7 @@ def test_predict_video_url_with_custom_sample_ms(channel):
             )
         ),
     )
-    response = stub.PostModelOutputs(request, metadata=metadata())
+    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
     raise_on_failure(response)
 
     # The expected time per frame is the middle between the start and the end of the frame
@@ -127,7 +128,7 @@ def test_predict_video_bytes(channel):
             )
         ],
     )
-    response = stub.PostModelOutputs(request, metadata=metadata())
+    response = post_model_outputs_with_retries(stub, request, metadata=metadata())
     raise_on_failure(response)
 
     assert len(response.outputs[0].data.frames) > 0


### PR DESCRIPTION
On non-prod, it's possible that PostModelOutputs will return a temporary 504 response.
We don't care about those as long as, after a few seconds, the response is a success.