### PR TITLE
Add testing PostModelOutputs on all public models

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -43,6 +43,7 @@ jobs:
       env:
         CLARIFAI_USER_EMAIL: ${{ secrets.CLARIFAI_USER_EMAIL }}
         CLARIFAI_USER_PASSWORD: ${{ secrets.CLARIFAI_USER_PASSWORD }}
+        INTERNAL_USER_PAT: ${{ secrets.INTERNAL_USER_PAT }}
       shell: bash
       run: |
         export PYTHONPATH=.

--- a/tests/common.py
+++ b/tests/common.py
@@ -18,6 +18,8 @@ BEER_VIDEO_URL = "https://samples.clarifai.com/beer.mp4"
 CONAN_GIF_VIDEO_URL = "https://samples.clarifai.com/3o6gb3kkXfLvdKEZs4.gif"
 TOY_VIDEO_FILE_PATH = os.path.dirname(__file__) + "/assets/toy.mp4"
 
+WEATHER_AUDIO_URL = "https://samples.clarifai.com/whatstheweatherlike.wav"
+
 APPAREL_MODEL_ID = "e0be3b9d6a454f0493ac3a30784001ff"
 COLOR_MODEL_ID = "eeed0b6733a644cea07cf4c60f87ebb7"
 DEMOGRAPHICS_MODEL_ID = "c0c0ac362b03416da06ab3fa36fb58e3"

--- a/tests/test_deep_training.py
+++ b/tests/test_deep_training.py
@@ -28,7 +28,7 @@ URLS = [
 
 
 def pat_key_metadata():
-    return (("authorization", "Key %s" % os.environ.get("CLARIFAI_PAT_KEY")),)
+    return (("authorization", "Key %s" % os.environ.get("INTERNAL_USER_PAT")),)
 
 
 def api_key_metadata(api_key: str):

--- a/tests/test_predict_on_all_public_models.py
+++ b/tests/test_predict_on_all_public_models.py
@@ -1,0 +1,125 @@
+from collections import defaultdict
+
+from clarifai_grpc.channel.clarifai_channel import ClarifaiChannel
+from clarifai_grpc.grpc.api import resources_pb2, service_pb2, service_pb2_grpc
+from tests.common import (
+    BEER_VIDEO_URL,
+    DOG_IMAGE_URL,
+    WEATHER_AUDIO_URL,
+    metadata,
+    raise_on_failure,
+)
+
+
+def test_predict_on_all_public_models():
+    stub = service_pb2_grpc.V2Stub(ClarifaiChannel.get_grpc_channel())
+
+    PREDICT_FUNC_PER_TYPE = {
+        "audio-embedder": _predict_audio_url,
+        "audio-to-text": _predict_audio_url,
+        "centroid-tracker": _predict_video_url,
+        "embedding-classifier": _predict_image_url,
+        "image-color-recognizer": _predict_image_url,
+        "image-crop": _predict_image_url,
+        "image-to-text": _predict_image_url,
+        "optical-character-recognizer": _predict_image_url,
+        "text-classifier": _predict_text,
+        "text-embedder": _predict_text,
+        "visual-classifier": _predict_image_url,
+        "visual-detector": _predict_image_url,
+        "visual-embedder": _predict_image_url,
+        "visual-detector-embedder": _predict_image_url,
+    }
+
+    # Get a list of all the available models (public and private).
+    all_models = []
+    page = 1
+    while True:
+        list_models_response = stub.ListModels(
+            service_pb2.ListModelsRequest(page=page, per_page=500), metadata=metadata()
+        )
+        raise_on_failure(list_models_response)
+
+        all_models.extend(list_models_response.models)
+
+        if len(list_models_response.models) < 500:
+            break
+
+        page += 1
+
+    models_per_type = defaultdict(list)
+    for model in all_models:
+        # All public models have 'app_id' set to 'main'. Other models are private.
+        if model.app_id == "main":
+            models_per_type[model.model_type_id].append(model)
+
+    print("\nPrediction table")
+    print("-" * 120)
+    print("{:30} | {:40} | {}".format("Model Type ID", "Model Name", "Model ID"))
+    print("-" * 120)
+    for model_type_id, models in models_per_type.items():
+        if model_type_id == "clusterer":
+            # It's not straightforward to do PostModelOutputs in a "clusterer" model. Probably it's safe
+            # to skip it.
+            continue
+
+        predict_func = PREDICT_FUNC_PER_TYPE.get(model_type_id)
+        if not predict_func:
+            print(f"Warning Model type '{model_type_id}' is not tested!")
+            continue
+
+        for model in models:
+            print("{:30} | {:40} | {}".format(model.model_type_id, model.name, model.id))
+            response = predict_func(stub, model)
+            raise_on_failure(
+                response,
+                f"Prediction failed on model {model.name} ({model.id}) of type {model.model_type_id}.",
+            )
+
+
+def _predict_audio_url(stub: service_pb2_grpc.V2Stub, model: resources_pb2.Model):
+    request = service_pb2.PostModelOutputsRequest(
+        model_id=model.id,
+        inputs=[
+            resources_pb2.Input(
+                data=resources_pb2.Data(audio=resources_pb2.Audio(url=WEATHER_AUDIO_URL))
+            )
+        ],
+    )
+    return stub.PostModelOutputs(request, metadata=metadata())
+
+
+def _predict_image_url(stub: service_pb2_grpc.V2Stub, model: resources_pb2.Model):
+    request = service_pb2.PostModelOutputsRequest(
+        model_id=model.id,
+        inputs=[
+            resources_pb2.Input(
+                data=resources_pb2.Data(image=resources_pb2.Image(url=DOG_IMAGE_URL))
+            )
+        ],
+    )
+    return stub.PostModelOutputs(request, metadata=metadata())
+
+
+def _predict_text(stub: service_pb2_grpc.V2Stub, model: resources_pb2.Model):
+    request = service_pb2.PostModelOutputsRequest(
+        model_id=model.id,
+        inputs=[
+            resources_pb2.Input(
+                data=resources_pb2.Data(text=resources_pb2.Text(raw="Hello, World!"))
+            )
+        ],
+    )
+    return stub.PostModelOutputs(request, metadata=metadata())
+
+
+def _predict_video_url(stub: service_pb2_grpc.V2Stub, model: resources_pb2.Model):
+    request = service_pb2.PostModelOutputsRequest(
+        model_id=model.id,
+        inputs=[
+            resources_pb2.Input(
+                data=resources_pb2.Data(video=resources_pb2.Video(url=BEER_VIDEO_URL))
+            )
+        ],
+    )
+    return stub.PostModelOutputs(request, metadata=metadata())

--- a/tests/test_predict_on_some_public_models.py
+++ b/tests/test_predict_on_some_public_models.py
@@ -41,6 +41,11 @@ MODEL_TITLE_AND_ID_PAIRS = [
 ]
 
 
+# These tests have been written before the "test predict on all public models" was done,
+# so they may not be needed any more. Still, they provide some value by breaking the test run
+# if one of the above models were to disappear.
+
+
 @both_channels
 def test_image_predict_on_public_models(channel):
     stub = service_pb2_grpc.V2Stub(channel)


### PR DESCRIPTION
This adds a test that goes through all public models and makes a `PostModelOutputs` (prediction) method call, to ensure the response is a success.