### PR TITLE
[TP-872] :bug: Fix missing user id

### DIFF
--- a/clarifai_grpc/channel/grpc_json_channel.py
+++ b/clarifai_grpc/channel/grpc_json_channel.py
@@ -221,7 +221,7 @@ def _read_app_info(data):
     elif type(data) is dict:
         for k, v in data.items():
             if k == "user_app_id":
-                return v["app_id"], v.get("user_id", "me")
+                return v.get("app_id", ""), v.get("user_id", "me")
             elif k == "apps":
                 if len(v) == 1:
                     return v[0]["id"], v[0].get("user_id", "me")

--- a/tests/test_collaborators.py
+++ b/tests/test_collaborators.py
@@ -9,7 +9,11 @@ def test_list_collaborators_with_pat(channel):
     stub = service_pb2_grpc.V2Stub(channel)
     metadata = (("authorization", "Key %s" % os.environ.get("CLARIFAI_PAT_KEY")),)
 
-    list_apps_response = stub.ListApps(service_pb2.ListAppsRequest(), metadata=metadata)
+    list_apps_response = stub.ListApps(service_pb2.ListAppsRequest(
+        user_app_id=resources_pb2.UserAppIDSet(
+            user_id="me",
+        )
+    ), metadata=metadata)
     # We should have at least one app. If this turns out not to be the case and the
     # test fails, we should create it in this test.
     assert list_apps_response.apps

--- a/tests/test_collaborators.py
+++ b/tests/test_collaborators.py
@@ -9,11 +9,14 @@ def test_list_collaborators_with_pat(channel):
     stub = service_pb2_grpc.V2Stub(channel)
     metadata = (("authorization", "Key %s" % os.environ.get("CLARIFAI_PAT_KEY")),)
 
-    list_apps_response = stub.ListApps(service_pb2.ListAppsRequest(
-        user_app_id=resources_pb2.UserAppIDSet(
-            user_id="me",
-        )
-    ), metadata=metadata)
+    list_apps_response = stub.ListApps(
+        service_pb2.ListAppsRequest(
+            user_app_id=resources_pb2.UserAppIDSet(
+                user_id="me",
+            )
+        ),
+        metadata=metadata,
+    )
     # We should have at least one app. If this turns out not to be the case and the
     # test fails, we should create it in this test.
     assert list_apps_response.apps


### PR DESCRIPTION
## Steps to Replicate
1. Run `test_list_collaborators_with_pat` test

## Expected Result
* Test passes

## Actual Result
* Test fails
```
17:57:45     @both_channels
17:57:45     def test_list_collaborators_with_pat(channel):
17:57:45         stub = service_pb2_grpc.V2Stub(channel)
17:57:45         metadata = (("authorization", "Key %s" % os.environ.get("CLARIFAI_PAT_KEY")),)
17:57:45     
17:57:45         list_apps_response = stub.ListApps(service_pb2.ListAppsRequest(), metadata=metadata)
17:57:45         # We should have at least one app. If this turns out not to be the case and the
17:57:45         # test fails, we should create it in this test.
17:57:45 >       assert list_apps_response.apps
17:57:45 E       assert []
17:57:45 E        +  where [] = status {\n  code: CONN_KEY_INVALID\n  description: "Invalid API key or Invalid API key/application pair"\n  details: "Nee...g/grpc@v1.29.1/server.go:746"\n  stack_trace: "runtime/asm_amd64.s:1373"\n  req_id: "eb73d363765f45268bbd3ac745741bab"\n}\n.apps
17:57:45 
17:57:45 tests/test_collaborators.py:15: AssertionError
```

## Cause
This is caused by recent commit which requires a `user_id` when calling `ListApps` endpoint.

## Fix
Add `user_id` when calling `ListApps` endpoint.