### PR TITLE
Added more information to output in case there is an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ request = service_pb2.PostModelOutputsRequest(
 response = stub.PostModelOutputs(request, metadata=metadata)
 
 if response.status.code != status_code_pb2.SUCCESS:
+    print("There was an error with your request!")
+    print("\tCode: {}".format(response.outputs[0].status.code))
+    print("\tDescription: {}".format(response.outputs[0].status.description))
+    print("\tDetails: {}".format(response.outputs[0].status.details))
     raise Exception("Request failed, status code: " + str(response.status.code))
 
 for concept in response.outputs[0].data.concepts:


### PR DESCRIPTION
Added additional output for context in the event there is an error.  Currently it will generally just print out 'Failure' to the user, versus the specific reason (too large of an image, etc.).