### PR TITLE
[EAGLE-1645] Register all bindings

### DIFF
--- a/clarifai_grpc/channel/grpc_json_channel.py
+++ b/clarifai_grpc/channel/grpc_json_channel.py
@@ -78,7 +78,7 @@ class GRPCJSONChannel(object):
             protobuf_name = "/" + service_descriptor.full_name + "/" + m.name
             self.name_to_resources[protobuf_name] = (m.input_type, [])
 
-            for http_rule in base_http_rule.additional_bindings or [base_http_rule]:
+            def register_bindings(http_rule):
                 # Get the url template and the method to use for http.
                 if http_rule.HasField("get"):
                     method = "GET"
@@ -99,6 +99,10 @@ class GRPCJSONChannel(object):
                     raise Exception("Failed to parse the grpc-gateway service spec.")
 
                 self.name_to_resources[protobuf_name][1].append((url_template, method))
+
+            register_bindings(base_http_rule)
+            for http_rule in base_http_rule.additional_bindings:
+                register_bindings(http_rule)
 
     def unary_unary(self, name, request_serializer, response_deserializer):
         # type: (str, typing.Callable, typing.Callable) -> JSONUnaryUnary


### PR DESCRIPTION
- Currently we are only registering the additional bindings or the original binding, but not both. I discovered this with this line: https://github.com/Clarifai/clarifai-python-grpc/blob/6e68e0b1d09e0ae5c76e28f7fa838f28ec39c20e/long_tests/test_deep_training.py#L114
We weren't registering the original DeleteModels bindings, so when using a PAT in the request, it was failing, because we weren't sending the app_id or user_id since the additional binding doesn't require it.