### PR TITLE
reduce video tests to only run on general model

### DIFF
--- a/tests/test_public_models_predicts.py
+++ b/tests/test_public_models_predicts.py
@@ -104,58 +104,58 @@ TEXT_MODEL_TITLE_IDS_TUPLE = [
 ]
 
 
-# @both_channels
-# def test_text_predict_on_public_models(channel):
-#     stub = service_pb2_grpc.V2Stub(channel)
+@both_channels
+def test_text_predict_on_public_models(channel):
+    stub = service_pb2_grpc.V2Stub(channel)
 
-#     for title, model_id, app_id, user_id in TEXT_MODEL_TITLE_IDS_TUPLE:
-#         if title == "translate romance":
-#             request = service_pb2.PostModelOutputsRequest(
-#                 user_app_id=resources_pb2.UserAppIDSet(user_id=user_id, app_id=app_id),
-#                 model_id=model_id,
-#                 inputs=[
-#                     resources_pb2.Input(
-#                         data=resources_pb2.Data(text=resources_pb2.Text(raw=SPANISH_TEXT))
-#                     )
-#                 ],
-#             )
-#         else:
-#             request = service_pb2.PostModelOutputsRequest(
-#                 user_app_id=resources_pb2.UserAppIDSet(user_id=user_id, app_id=app_id),
-#                 model_id=model_id,
-#                 inputs=[
-#                     resources_pb2.Input(
-#                         data=resources_pb2.Data(text=resources_pb2.Text(raw=ENGLISH_TEXT))
-#                     )
-#                 ],
-#             )
-#         response = post_model_outputs_and_maybe_allow_retries(
-#             stub, request, metadata=metadata(pat=True)
-#         )
-#         raise_on_failure(
-#             response,
-#             custom_message=f"Text predict failed for the {title} model (ID: {model_id}).",
-#         )
+    for title, model_id, app_id, user_id in TEXT_MODEL_TITLE_IDS_TUPLE:
+        if title == "translate romance":
+            request = service_pb2.PostModelOutputsRequest(
+                user_app_id=resources_pb2.UserAppIDSet(user_id=user_id, app_id=app_id),
+                model_id=model_id,
+                inputs=[
+                    resources_pb2.Input(
+                        data=resources_pb2.Data(text=resources_pb2.Text(raw=SPANISH_TEXT))
+                    )
+                ],
+            )
+        else:
+            request = service_pb2.PostModelOutputsRequest(
+                user_app_id=resources_pb2.UserAppIDSet(user_id=user_id, app_id=app_id),
+                model_id=model_id,
+                inputs=[
+                    resources_pb2.Input(
+                        data=resources_pb2.Data(text=resources_pb2.Text(raw=ENGLISH_TEXT))
+                    )
+                ],
+            )
+        response = post_model_outputs_and_maybe_allow_retries(
+            stub, request, metadata=metadata(pat=True)
+        )
+        raise_on_failure(
+            response,
+            custom_message=f"Text predict failed for the {title} model (ID: {model_id}).",
+        )
 
 
-# @both_channels
-# def test_image_predict_on_public_models(channel):
-#     stub = service_pb2_grpc.V2Stub(channel)
+@both_channels
+def test_image_predict_on_public_models(channel):
+    stub = service_pb2_grpc.V2Stub(channel)
 
-#     for title, model_id in MODEL_TITLE_AND_ID_PAIRS:
-#         request = service_pb2.PostModelOutputsRequest(
-#             model_id=model_id,
-#             inputs=[
-#                 resources_pb2.Input(
-#                     data=resources_pb2.Data(image=resources_pb2.Image(url=DOG_IMAGE_URL))
-#                 )
-#             ],
-#         )
-#         response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
-#         raise_on_failure(
-#             response,
-#             custom_message=f"Image predict failed for the {title} model (ID: {model_id}).",
-#         )
+    for title, model_id in MODEL_TITLE_AND_ID_PAIRS:
+        request = service_pb2.PostModelOutputsRequest(
+            model_id=model_id,
+            inputs=[
+                resources_pb2.Input(
+                    data=resources_pb2.Data(image=resources_pb2.Image(url=DOG_IMAGE_URL))
+                )
+            ],
+        )
+        response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
+        raise_on_failure(
+            response,
+            custom_message=f"Image predict failed for the {title} model (ID: {model_id}).",
+        )
 
 
 @both_channels

--- a/tests/test_public_models_predicts.py
+++ b/tests/test_public_models_predicts.py
@@ -104,81 +104,77 @@ TEXT_MODEL_TITLE_IDS_TUPLE = [
 ]
 
 
-@both_channels
-def test_text_predict_on_public_models(channel):
-    stub = service_pb2_grpc.V2Stub(channel)
+# @both_channels
+# def test_text_predict_on_public_models(channel):
+#     stub = service_pb2_grpc.V2Stub(channel)
 
-    for title, model_id, app_id, user_id in TEXT_MODEL_TITLE_IDS_TUPLE:
-        if title == "translate romance":
-            request = service_pb2.PostModelOutputsRequest(
-                user_app_id=resources_pb2.UserAppIDSet(user_id=user_id, app_id=app_id),
-                model_id=model_id,
-                inputs=[
-                    resources_pb2.Input(
-                        data=resources_pb2.Data(text=resources_pb2.Text(raw=SPANISH_TEXT))
-                    )
-                ],
-            )
-        else:
-            request = service_pb2.PostModelOutputsRequest(
-                user_app_id=resources_pb2.UserAppIDSet(user_id=user_id, app_id=app_id),
-                model_id=model_id,
-                inputs=[
-                    resources_pb2.Input(
-                        data=resources_pb2.Data(text=resources_pb2.Text(raw=ENGLISH_TEXT))
-                    )
-                ],
-            )
-        response = post_model_outputs_and_maybe_allow_retries(
-            stub, request, metadata=metadata(pat=True)
-        )
-        raise_on_failure(
-            response,
-            custom_message=f"Text predict failed for the {title} model (ID: {model_id}).",
-        )
+#     for title, model_id, app_id, user_id in TEXT_MODEL_TITLE_IDS_TUPLE:
+#         if title == "translate romance":
+#             request = service_pb2.PostModelOutputsRequest(
+#                 user_app_id=resources_pb2.UserAppIDSet(user_id=user_id, app_id=app_id),
+#                 model_id=model_id,
+#                 inputs=[
+#                     resources_pb2.Input(
+#                         data=resources_pb2.Data(text=resources_pb2.Text(raw=SPANISH_TEXT))
+#                     )
+#                 ],
+#             )
+#         else:
+#             request = service_pb2.PostModelOutputsRequest(
+#                 user_app_id=resources_pb2.UserAppIDSet(user_id=user_id, app_id=app_id),
+#                 model_id=model_id,
+#                 inputs=[
+#                     resources_pb2.Input(
+#                         data=resources_pb2.Data(text=resources_pb2.Text(raw=ENGLISH_TEXT))
+#                     )
+#                 ],
+#             )
+#         response = post_model_outputs_and_maybe_allow_retries(
+#             stub, request, metadata=metadata(pat=True)
+#         )
+#         raise_on_failure(
+#             response,
+#             custom_message=f"Text predict failed for the {title} model (ID: {model_id}).",
+#         )
 
 
-@both_channels
-def test_image_predict_on_public_models(channel):
-    stub = service_pb2_grpc.V2Stub(channel)
+# @both_channels
+# def test_image_predict_on_public_models(channel):
+#     stub = service_pb2_grpc.V2Stub(channel)
 
-    for title, model_id in MODEL_TITLE_AND_ID_PAIRS:
-        request = service_pb2.PostModelOutputsRequest(
-            model_id=model_id,
-            inputs=[
-                resources_pb2.Input(
-                    data=resources_pb2.Data(image=resources_pb2.Image(url=DOG_IMAGE_URL))
-                )
-            ],
-        )
-        response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
-        raise_on_failure(
-            response,
-            custom_message=f"Image predict failed for the {title} model (ID: {model_id}).",
-        )
+#     for title, model_id in MODEL_TITLE_AND_ID_PAIRS:
+#         request = service_pb2.PostModelOutputsRequest(
+#             model_id=model_id,
+#             inputs=[
+#                 resources_pb2.Input(
+#                     data=resources_pb2.Data(image=resources_pb2.Image(url=DOG_IMAGE_URL))
+#                 )
+#             ],
+#         )
+#         response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
+#         raise_on_failure(
+#             response,
+#             custom_message=f"Image predict failed for the {title} model (ID: {model_id}).",
+#         )
 
 
 @both_channels
 def test_video_predict_on_public_models(channel):
     stub = service_pb2_grpc.V2Stub(channel)
 
-    models_with_no_video_support = {
-        "color",
-    }
+    title = "general"
+    model_id = GENERAL_MODEL_ID
 
-    for title, model_id in MODEL_TITLE_AND_ID_PAIRS:
-        if title in models_with_no_video_support:
-            continue
-        request = service_pb2.PostModelOutputsRequest(
-            model_id=model_id,
-            inputs=[
-                resources_pb2.Input(
-                    data=resources_pb2.Data(video=resources_pb2.Video(url=BEER_VIDEO_URL))
-                )
-            ],
-        )
-        response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
-        raise_on_failure(
-            response,
-            custom_message=f"Video predict failed for the {title} model (ID: {model_id}).",
-        )
+    request = service_pb2.PostModelOutputsRequest(
+        model_id=model_id,
+        inputs=[
+            resources_pb2.Input(
+                data=resources_pb2.Data(video=resources_pb2.Video(url=BEER_VIDEO_URL))
+            )
+        ],
+    )
+    response = post_model_outputs_and_maybe_allow_retries(stub, request, metadata=metadata())
+    raise_on_failure(
+        response,
+        custom_message=f"Video predict failed for the {title} model (ID: {model_id}).",
+    )


### PR DESCRIPTION
Video model tests don’t test the models in a different way than the existing image tests. The video tests only test the media processing assuming image tests are passing. This PR will change video tests to only run on the general model.