### PR TITLE
[TP-1138] :recycle: Fix raising error in app_and_key_for_tests.py

### DIFF
--- a/scripts/app_and_key_for_tests.py
+++ b/scripts/app_and_key_for_tests.py
@@ -39,9 +39,8 @@ def _request(method, url, payload={}, headers={}):
             error_body = json.dumps(json.loads(error_body), indent=4)
         except:
             pass
-        print("ERROR after a HTTP request to: %s %s" % (method, full_url))
-        print("%d %s:\n%s" % (e.code, e.reason, error_body))
-        os._exit(1)
+        raise Exception("ERROR after a HTTP request to: %s %s" % (method, full_url)
+                        + ". Response: %d %s:\n%s" % (e.code, e.reason, error_body))
     return json.loads(response)
 
 


### PR DESCRIPTION
## Issue
When running `export APP_ID=$(python $CLARIFAI_PYTHON_GRPC_ROOT/scripts/app_and_key_for_tests.py --create-app python-github)` , no output is displayed in case of error.

## Fix
* Replace usage of `print` and `os._exit` with `raise`.
