### PR TITLE
[EAGLE-2594] fix race condition

### DIFF
--- a/tests/client/test_secure_data_hosting.py
+++ b/tests/client/test_secure_data_hosting.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 import requests
+import time
 
 from clarifai_grpc.grpc.api import service_pb2_grpc, service_pb2, resources_pb2
 from tests.common import (
@@ -140,9 +141,9 @@ def verify_url_with_bad_auth(expected_input_url):
 def test_adding_inputs(channel):
     stub = service_pb2_grpc.V2Stub(channel)
 
-    input_img1 = "truck-img"
-    input_img2 = "travel-img"
-    input_vid1 = "beer-vid"
+    input_img1 = "truck-img-" + str(time.time())
+    input_img2 = "travel-img-" + str(time.time())
+    input_vid1 = "beer-vid-" + str(time.time())
 
     bytes_hash_by_id = {
         input_img1: get_bytes_hash_from_url(TRUCK_IMAGE_URL),

--- a/tests/client/test_secure_data_hosting.py
+++ b/tests/client/test_secure_data_hosting.py
@@ -141,9 +141,9 @@ def verify_url_with_bad_auth(expected_input_url):
 def test_adding_inputs(channel):
     stub = service_pb2_grpc.V2Stub(channel)
 
-    input_img1 = "truck-img-" + str(time.time())
-    input_img2 = "travel-img-" + str(time.time())
-    input_vid1 = "beer-vid-" + str(time.time())
+    input_img1 = "truck-img-" + str(time.time()).replace(".", "-")
+    input_img2 = "travel-img-" + str(time.time()).replace(".", "-")
+    input_vid1 = "beer-vid-" + str(time.time()).replace(".", "-")
 
     bytes_hash_by_id = {
         input_img1: get_bytes_hash_from_url(TRUCK_IMAGE_URL),


### PR DESCRIPTION
deletes are async and posting sometime errors out because we test with two channels (JSON/GRPC) back-to-back