### PR TITLE
[LT-4282] Update SDH expected status

### DIFF
--- a/tests/client/test_secure_data_hosting.py
+++ b/tests/client/test_secure_data_hosting.py
@@ -134,9 +134,7 @@ def verify_url_with_bad_auth(expected_input_url):
 
     # No header/cookie results should result in NOT FOUND (404)
     r = req_session.get(expected_input_url, stream=True)
-    assert (
-        r.status_code == 404
-    ), f"Expected Code: 404, Actual: {r.status_code}"
+    assert r.status_code == 404, f"Expected Code: 404, Actual: {r.status_code}"
 
 
 @both_channels

--- a/tests/client/test_secure_data_hosting.py
+++ b/tests/client/test_secure_data_hosting.py
@@ -134,10 +134,9 @@ def verify_url_with_bad_auth(expected_input_url):
 
     # No header/cookie results should result in NOT FOUND (404)
     r = req_session.get(expected_input_url, stream=True)
-    assert r.status_code in [
-        400,
-        404,
-    ], f"Expected Code: 404, Actual: {r.status_code}"  # temporarily allow old status 400
+    assert (
+        r.status_code == 404
+    ), f"Expected Code: 404, Actual: {r.status_code}"
 
 
 @both_channels


### PR DESCRIPTION
### Why
* No need to support old status `400` in tests