### PR TITLE
[TP-1314] :bug: Fix using unsupported search field

### DIFF
--- a/tests/client/test_input_search_legacy.py
+++ b/tests/client/test_input_search_legacy.py
@@ -221,8 +221,10 @@ def test_search_by_image_bytes(channel):
                     ands=[
                         resources_pb2.And(
                             output=resources_pb2.Output(
-                                data=resources_pb2.Data(
-                                    image=resources_pb2.Image(base64=url_bytes)
+                                input=resources_pb2.Input(
+                                    data=resources_pb2.Data(
+                                        image=resources_pb2.Image(base64=url_bytes)
+                                    )
                                 )
                             )
                         )


### PR DESCRIPTION
### Why
* Strict validation for search unsupported fields was enabled.
* Test `tests/client/test_input_search_legacy.py::test_search_by_image_bytes` started to fail with error `40002 Invalid search request Search output has unsupported field set: 'data.image.base64[]'. Did you mean to set 'input.data.image.base64[]'? Check your request fields.`
* Searching using `data.image.base64[]` field did actually not perform any ranking. The field was ignored.
* In order to perform ranking by image bytes, we need to use `input.data.image.base64[]` field.

### Fix
* Use `input.data.image.base64[]` instead of `data.image.base64[]`