### PR TITLE
[TP-1333] :recycle: Remove test temporary expected status code

### DIFF
--- a/tests/client/test_image_predict.py
+++ b/tests/client/test_image_predict.py
@@ -177,10 +177,11 @@ def test_failed_predict(channel):
         stub, request, metadata=metadata(pat=True)
     )
 
-    assert response.status.code in [
-        status_code_pb2.FAILURE,  # temporarily allow old status
-        status_code_pb2.INPUT_DOWNLOAD_FAILED,
-    ]
+    assert response.status.code == status_code_pb2.INPUT_DOWNLOAD_FAILED
+    assert (
+        response.status.details == "404 Client Error: Not Found for url: "
+        "http://example.com/non-existing.jpg"
+    )
 
     assert response.outputs[0].status.code == status_code_pb2.INPUT_DOWNLOAD_FAILED
     assert (


### PR DESCRIPTION
### Why
All environments should now return `INPUT_DOWNLOAD_FAILED` status for `test_failed_predict`