### PR TITLE
Allow non https schemes in grpc test scripts

### DIFF
--- a/scripts/app_and_key_for_tests.py
+++ b/scripts/app_and_key_for_tests.py
@@ -25,9 +25,10 @@ def _assert_response_success(response):
 
 def _request(method, url, payload={}, headers={}):
     base_url = os.environ.get("CLARIFAI_GRPC_BASE", "api.clarifai.com")
+    base_scheme = os.environ.get("CLARIFAI_GRPC_BASE_SCHEME", "https")
 
     opener = build_opener(HTTPHandler)
-    full_url = f"https://{base_url}/v2{url}"
+    full_url = f"{base_scheme}://{base_url}/v2{url}"
     request = Request(full_url, data=json.dumps(payload).encode())
     for k in headers.keys():
         request.add_header(k, headers[k])


### PR DESCRIPTION
We want these scripts to be more flexible to use in non https situations