### PR TITLE
[TP-1432] test_failed_predict client test fails due to 500 err

### DIFF
--- a/tests/client/test_image_predict.py
+++ b/tests/client/test_image_predict.py
@@ -178,16 +178,18 @@ def test_failed_predict(channel):
     )
 
     assert response.status.code == status_code_pb2.INPUT_DOWNLOAD_FAILED
-    assert (
-        response.status.details == "404 Client Error: Not Found for url: "
-        "http://example.com/non-existing.jpg"
-    )
+    # Disabled as the example.com domain started returning 500 errors instead
+    # assert (
+    #     response.status.details == "404 Client Error: Not Found for url: "
+    #     "http://example.com/non-existing.jpg"
+    # )
 
     assert response.outputs[0].status.code == status_code_pb2.INPUT_DOWNLOAD_FAILED
-    assert (
-        response.outputs[0].status.details == "404 Client Error: Not Found for url: "
-        "http://example.com/non-existing.jpg"
-    )
+    # Disabled as the example.com domain started returning 500 errors instead
+    # assert (
+    #     response.outputs[0].status.details == "404 Client Error: Not Found for url: "
+    #     "http://example.com/non-existing.jpg"
+    # )
 
 
 @both_channels


### PR DESCRIPTION
The used link http://example.com/non-existing.jpg now returns 500 error instead. Disabling the details check.