### PR TITLE
[DEVX-400] Add custom root certificates support

### DIFF
--- a/clarifai_grpc/channel/clarifai_channel.py
+++ b/clarifai_grpc/channel/clarifai_channel.py
@@ -62,16 +62,23 @@ class ClarifaiChannel:
         return session
 
     @staticmethod
-    def get_grpc_channel(base=None):
+    def get_grpc_channel(base=None, root_certificates_path=None):
         global wrap_response_deserializer
         wrap_response_deserializer = _response_deserializer_for_grpc
 
         if not base:
             base = os.environ.get("CLARIFAI_GRPC_BASE", "api.clarifai.com")
 
+        if root_certificates_path:
+            with open(root_certificates_path, "rb") as f:
+                root_certificates = f.read()
+            credentials = grpc.ssl_channel_credentials(root_certificates)
+        else:
+            credentials = grpc.ssl_channel_credentials()
+
         return service_pb2_grpc.grpc.secure_channel(
             base,
-            service_pb2_grpc.grpc.ssl_channel_credentials(),
+            credentials,
             options=[
                 ("grpc.service_config", grpc_json_config),
                 ("grpc.max_receive_message_length", MAX_MESSAGE_LENGTH),

--- a/clarifai_grpc/channel/clarifai_channel.py
+++ b/clarifai_grpc/channel/clarifai_channel.py
@@ -72,9 +72,9 @@ class ClarifaiChannel:
         if root_certificates_path:
             with open(root_certificates_path, "rb") as f:
                 root_certificates = f.read()
-            credentials = grpc.ssl_channel_credentials(root_certificates)
+            credentials = service_pb2_grpc.grpc.ssl_channel_credentials(root_certificates)
         else:
-            credentials = grpc.ssl_channel_credentials()
+            credentials = service_pb2_grpc.grpc.ssl_channel_credentials()
 
         return service_pb2_grpc.grpc.secure_channel(
             base,


### PR DESCRIPTION
## Why 
 - Add custom root certificates support for secure gRPC connection

## Tests

Manual local tests with openssl generated server cred, key

Server
```python
import grpc
from concurrent import futures
from clarifai_grpc.grpc.api import service_pb2_grpc
from clarifai_grpc.grpc.api import service_pb2
from clarifai_grpc.grpc.api.status import status_pb2
import time

class ImagePredictionService(service_pb2_grpc.V2Servicer):
    def PostModelOutputs(self, request, context):
        print("Received a PostModelOutputsRequest")
        # Dummy response
        return service_pb2.MultiOutputResponse(
            status=status_pb2.Status(code=10000, description="Success")
        )

# Load server's certificate and key
with open('/Users/sainivedh/Desktop/server.crt', 'rb') as f:
    server_certificate = f.read()
with open('/Users/sainivedh/Desktop/server.key', 'rb') as f:
    server_private_key = f.read()

server_credentials = service_pb2_grpc.grpc.ssl_server_credentials(((server_private_key, server_certificate,),))

server = service_pb2_grpc.grpc.server(futures.ThreadPoolExecutor(max_workers=10))
service_pb2_grpc.add_V2Servicer_to_server(ImagePredictionService(), server)
server.add_secure_port('[::]:50051', server_credentials)

server.start()
print("Server started. Listening on '[::]:50051'.")

try:
    while True:
        time.sleep(86400)
except KeyboardInterrupt:
    server.stop(0)
    print("Server stopped.")
```

Client

```python
import grpc
from clarifai_grpc.grpc.api import service_pb2_grpc, service_pb2
from clarifai_grpc.grpc.api import resources_pb2
from clarifai_grpc.channel.clarifai_channel import ClarifaiChannel

with open('/Users/sainivedh/Desktop/ca.crt', 'rb') as f:
    ca_certificate = f.read()

channel = ClarifaiChannel.get_grpc_channel("localhost:50051", '/Users/sainivedh/Desktop/ca.crt')

stub = service_pb2_grpc.V2Stub(channel)

userDataObject = resources_pb2.UserAppIDSet(user_id="clarifai", app_id="main")
request = service_pb2.PostModelOutputsRequest(
    user_app_id=userDataObject,
    model_id="MODEL_ID",
    inputs=[
        resources_pb2.Input(
            data=resources_pb2.Data(image=resources_pb2.Image(url="IMAGE_URL"))
        )
    ],
)

try:
    response = stub.PostModelOutputs(request)
    print("Response received: ", response)
except grpc.RpcError as e:
    print(f"RPC failed: {e.code()}, {e.details()}")
```

Output
```
Response received:  status {
  code: SUCCESS
  description: "Success"
}
```
