### PR TITLE
[TP-1454] Fix channel missing attributes

### DIFF
--- a/clarifai_grpc/channel/errors.py
+++ b/clarifai_grpc/channel/errors.py
@@ -1,10 +1,10 @@
 class ApiError(Exception):
     pass
 
-class NotImplementedCaller:
 
-  def __call__(self, *args, **kwargs):
-    raise NotImplementedError()
+class NotImplementedCaller:
+    def __call__(self, *args, **kwargs):
+        raise NotImplementedError()
 
 
 class UsageError(Exception):

--- a/clarifai_grpc/channel/errors.py
+++ b/clarifai_grpc/channel/errors.py
@@ -1,6 +1,11 @@
 class ApiError(Exception):
     pass
 
+class NotImplementedCaller:
+
+  def __call__(self, *args, **kwargs):
+    raise NotImplementedError()
+
 
 class UsageError(Exception):
     pass

--- a/clarifai_grpc/channel/grpc_json_channel.py
+++ b/clarifai_grpc/channel/grpc_json_channel.py
@@ -10,7 +10,7 @@ from google.protobuf.message import Message  # noqa
 from clarifai_grpc.channel import http_client
 from clarifai_grpc.channel.custom_converters.custom_dict_to_message import dict_to_protobuf
 from clarifai_grpc.channel.custom_converters.custom_message_to_dict import protobuf_to_dict
-from clarifai_grpc.channel.errors import UsageError
+from clarifai_grpc.channel.errors import UsageError, NotImplementedCaller
 from clarifai_grpc.channel.exceptions import ClarifaiException
 from clarifai_grpc.grpc.api.service_pb2 import _V2
 
@@ -116,6 +116,9 @@ class GRPCJSONChannel(object):
             response_deserializer,
         )
 
+    def unary_stream(self, method, request_serializer=None, response_deserializer=None):
+        return NotImplementedCaller()
+
     def stream_stream(self, name, request_serializer, response_deserializer):
         # type: (str, typing.Callable, typing.Callable) -> JSONStreamStream
         """Method to create the callable JSONStreamStream."""
@@ -127,6 +130,9 @@ class GRPCJSONChannel(object):
             request_serializer,
             response_deserializer,
         )
+
+    def stream_unary(self, method, request_serializer=None, response_deserializer=None):
+        return NotImplementedCaller()
 
 
 class JSONUnaryUnary(object):


### PR DESCRIPTION
### Why
```
FAILED tests/client/test_collaborators.py::test_list_collaborators_with_pat - AttributeError: 'GRPCJSONChannel' object has no attribute 'unary_stream'
```

### How
* To quickly fix this, add the missing methods and mark them as not implemented. This will allow the channel to be initialised without breaking.