### PR TITLE
Allow insecure grpc during tests

### DIFF
--- a/scripts/app_and_key_for_tests.py
+++ b/scripts/app_and_key_for_tests.py
@@ -29,7 +29,7 @@ def _request(method, url, payload={}, headers={}):
     base_scheme = os.environ.get("CLARIFAI_GRPC_BASE_SCHEME", "https")
 
     if base_url_port != '':
-        base_url = base_url + ':' + base_url_port
+        base_url = f"{base_url}:{base_url_port}"
 
     full_url = f"{base_scheme}://{base_url}/v2{url}"
 

--- a/scripts/app_and_key_for_tests.py
+++ b/scripts/app_and_key_for_tests.py
@@ -25,10 +25,16 @@ def _assert_response_success(response):
 
 def _request(method, url, payload={}, headers={}):
     base_url = os.environ.get("CLARIFAI_GRPC_BASE", "api.clarifai.com")
+    base_url_port = os.environ.get("CLARIFAI_GRPC_BASE_PORT", "")
     base_scheme = os.environ.get("CLARIFAI_GRPC_BASE_SCHEME", "https")
 
-    opener = build_opener(HTTPHandler)
+    if base_url_port != '':
+        base_url = base_url + ':' + base_url_port
+
     full_url = f"{base_scheme}://{base_url}/v2{url}"
+
+    opener = build_opener(HTTPHandler)
+
     request = Request(full_url, data=json.dumps(payload).encode())
     for k in headers.keys():
         request.add_header(k, headers[k])

--- a/scripts/app_and_key_for_tests.py
+++ b/scripts/app_and_key_for_tests.py
@@ -28,7 +28,7 @@ def _request(method, url, payload={}, headers={}):
     base_url_port = os.environ.get("CLARIFAI_GRPC_BASE_PORT", "")
     base_scheme = os.environ.get("CLARIFAI_GRPC_BASE_SCHEME", "https")
 
-    if base_url_port != '':
+    if base_url_port != "":
         base_url = f"{base_url}:{base_url_port}"
 
     full_url = f"{base_scheme}://{base_url}/v2{url}"

--- a/tests/common.py
+++ b/tests/common.py
@@ -56,6 +56,8 @@ def both_channels(func):
 
     def func_wrapper():
         channel = ClarifaiChannel.get_grpc_channel()
+        if os.environ.get("CLARIFAI_GRPC_INSECURE", "false"):
+            channel = ClarifaiChannel.get_insecure_grpc_channel(port=443)
         func(channel)
 
         channel = ClarifaiChannel.get_json_channel()

--- a/tests/common.py
+++ b/tests/common.py
@@ -56,7 +56,7 @@ def both_channels(func):
 
     def func_wrapper():
         channel = ClarifaiChannel.get_grpc_channel()
-        if os.environ.get("CLARIFAI_GRPC_INSECURE", "false"):
+        if os.getenv("CLARIFAI_GRPC_INSECURE", "False").lower() in ("true", "1", "t"):
             channel = ClarifaiChannel.get_insecure_grpc_channel(port=443)
         func(channel)
 


### PR DESCRIPTION
We want to be able to run these tests without a secure grpc channel