### PR TITLE
[LT-5283] Fix setting authorization for SDH urls

### DIFF
--- a/tests/client/test_dataset_version_export.py
+++ b/tests/client/test_dataset_version_export.py
@@ -174,8 +174,8 @@ def _check_export(export, expected_format, expected_mimetype, check_fn):
     assert export.size > 0
 
     get_export_url_response = requests.get(
-        export.url,
-        headers=headers() if export.url.startswith(get_secure_hosting_url()) else None)
+        export.url, headers=headers() if export.url.startswith(get_secure_hosting_url()) else None
+    )
     assert get_export_url_response.status_code == 200
 
     with zipfile.ZipFile(io.BytesIO(get_export_url_response.content)) as zip_file:

--- a/tests/client/test_dataset_version_export.py
+++ b/tests/client/test_dataset_version_export.py
@@ -10,6 +10,7 @@ from tests.common import (
     DOG_IMAGE_URL,
     TRUCK_IMAGE_URL,
     both_channels,
+    headers,
     metadata,
     raise_on_failure,
     wait_for_inputs_delete,
@@ -172,10 +173,9 @@ def _check_export(export, expected_format, expected_mimetype, check_fn):
     assert export.format == expected_format
     assert export.size > 0
 
-    headers = None
-    if export.url.startswith(get_secure_hosting_url()):
-        headers = metadata()
-    get_export_url_response = requests.get(export.url, headers=headers)
+    get_export_url_response = requests.get(
+        export.url,
+        headers=headers() if export.url.startswith(get_secure_hosting_url()) else None)
     assert get_export_url_response.status_code == 200
 
     with zipfile.ZipFile(io.BytesIO(get_export_url_response.content)) as zip_file:

--- a/tests/common.py
+++ b/tests/common.py
@@ -40,6 +40,13 @@ def get_status_message(status: Status):
         return message
 
 
+def headers(pat=False):
+    if pat:
+        return {"authorization": "Key %s" % os.environ.get("CLARIFAI_PAT_KEY")}
+    else:
+        return {"authorization": "Key %s" % os.environ.get("CLARIFAI_API_KEY")}
+
+
 def metadata(pat=False):
     if pat:
         return (("authorization", "Key %s" % os.environ.get("CLARIFAI_PAT_KEY")),)


### PR DESCRIPTION
### Why
* Previous commit 22b717e70c651c87a9a8641149489157d3c11f5f did not set the headers as expected, which caused ` AttributeError: 'tuple' object has no attribute 'items'` error

#### How
* Set headers in a map instead of a list