### PR TITLE
[EAGLE-4649] add retry to wait_for_model_trained

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -122,7 +122,9 @@ def wait_for_inputs_delete(stub, input_ids, metadata):
         raise Exception(f"Timeout after {timeout} seconds to delete inputs {remaining_input_ids}")
 
 
-def wait_for_model_trained(stub, metadata, model_id, model_version_id, user_app_id=None, retry_on_internal_failure=False):
+def wait_for_model_trained(
+    stub, metadata, model_id, model_version_id, user_app_id=None, retry_on_internal_failure=False
+):
     retry_count = 0
     while True:
         response = stub.GetModelVersion(
@@ -132,7 +134,11 @@ def wait_for_model_trained(stub, metadata, model_id, model_version_id, user_app_
             metadata=metadata,
         )
         ## Temp fix for EAGLE-4649 until LT-5281 is implemented.
-        if retry_on_internal_failure and response.status.code == status_code_pb2.INTERNAL_UNCATEGORIZED and retry_count < 3:
+        if (
+            retry_on_internal_failure
+            and response.status.code == status_code_pb2.INTERNAL_UNCATEGORIZED
+            and retry_count < 3
+        ):
             print(f"Retrying: {response.status}")
             retry_count += 1
             continue

--- a/tests/common.py
+++ b/tests/common.py
@@ -122,7 +122,8 @@ def wait_for_inputs_delete(stub, input_ids, metadata):
         raise Exception(f"Timeout after {timeout} seconds to delete inputs {remaining_input_ids}")
 
 
-def wait_for_model_trained(stub, metadata, model_id, model_version_id, user_app_id=None):
+def wait_for_model_trained(stub, metadata, model_id, model_version_id, user_app_id=None, retry_on_internal_failure=False):
+    retry_count = 0
     while True:
         response = stub.GetModelVersion(
             service_pb2.GetModelVersionRequest(
@@ -130,6 +131,12 @@ def wait_for_model_trained(stub, metadata, model_id, model_version_id, user_app_
             ),
             metadata=metadata,
         )
+        ## Temp fix for EAGLE-4649 until LT-5281 is implemented.
+        if retry_on_internal_failure and response.status.code == status_code_pb2.INTERNAL_UNCATEGORIZED and retry_count < 3:
+            print(f"Retrying: {response.status}")
+            retry_count += 1
+            continue
+
         raise_on_failure(response)
         if response.model_version.status.code == status_code_pb2.MODEL_TRAINED:
             break


### PR DESCRIPTION
Temporary fix to handle seemingly transient AWS errors until LT-5281 is implemented (should be picked up by DaLi in the next sprint starting in 1 week).

Expect to alleviate the deep train client test alerts, but will not resolve the timeout errors.

Since `deep-training-client-tests` [checks out this repo](https://github.com/Clarifai/crons-api-client-tests/blob/f05b7ca6349b26c3a726389969cdf84c46a76dc9/.github/workflows/deep-training-client-tests.yml#L34), we do not need to bump versions. We should also merge this PR before https://github.com/Clarifai/crons-api-client-tests/pull/74.