### PR TITLE
move import of request lib to when needed so it's not a dependency

### DIFF
--- a/clarifai_grpc/channel/clarifai_channel.py
+++ b/clarifai_grpc/channel/clarifai_channel.py
@@ -1,8 +1,6 @@
 import json
 import os
 
-import requests
-
 from clarifai_grpc.channel.grpc_json_channel import GRPCJSONChannel
 from clarifai_grpc.grpc.api import service_pb2_grpc
 
@@ -52,6 +50,7 @@ class ClarifaiChannel:
 
     @staticmethod
     def _make_requests_session():
+        import requests  # noqa
         http_adapter = requests.adapters.HTTPAdapter(
             max_retries=RETRIES, pool_connections=CONNECTIONS, pool_maxsize=CONNECTIONS
         )

--- a/clarifai_grpc/channel/grpc_json_channel.py
+++ b/clarifai_grpc/channel/grpc_json_channel.py
@@ -3,7 +3,6 @@ import logging
 import re
 import typing  # noqa
 
-import requests  # noqa
 from google.protobuf.descriptor import Descriptor  # noqa
 from google.protobuf.message import Message  # noqa
 
@@ -43,7 +42,7 @@ class GRPCJSONChannel(object):
 
     def __init__(
         self,
-        session: requests.Session,
+        session # type: requests.Session,
         base_url: str = BASE_URL,
         service_descriptor: typing.Any = _V2,
     ) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
-googleapis-common-protos==1.57.0
 grpcio==1.51.0
 protobuf==3.20.3
-requests==2.28.1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,3 +2,4 @@ autoflake==1.4
 black==22.3.0
 pytest==6.2.2
 pytest-xdist==2.2.1
+requests==2.28.1


### PR DESCRIPTION
In order to make our clarifai SDK not depend on many packages and keep our containers smaller I noticed that we have requests here which is only needed if using the json channel whichis not the recommended way when using python. 

I'm also not seeing where we need the google dependency in the code so removed that as well.