### PR TITLE
[TP-1788] Fix flaky test_adding_inputs

### DIFF
--- a/tests/client/test_secure_data_hosting.py
+++ b/tests/client/test_secure_data_hosting.py
@@ -205,7 +205,11 @@ def test_adding_inputs(channel_key):
 
         # list input
         list_inputs_response = stub.ListInputs(
-            service_pb2.ListInputsRequest(per_page=10), metadata=API_CLIENT_AUTH
+            service_pb2.ListInputsRequest(
+                ids=bytes_hash_by_id.keys(),
+                per_page=10,
+            ),
+            metadata=API_CLIENT_AUTH,
         )
         raise_on_failure(list_inputs_response)
         assert len(list_inputs_response.inputs) == len(bytes_hash_by_id.keys())


### PR DESCRIPTION
### Why
* When running tests using multiple parallel workers, `test_adding_inputs[grpc]` & `test_adding_inputs[json]` may fail with assertion error `assert 6 == 3` because each test adds 3 inputs in the same app.

### How
* Filter by input IDs, when calling `ListInputs` to make sure that inputs from any other tests are not returned