### PR TITLE
warn and unset env var when using python protobuf implementation for speed

### DIFF
--- a/clarifai_grpc/__init__.py
+++ b/clarifai_grpc/__init__.py
@@ -1,1 +1,21 @@
 __version__ = "11.7.3"
+
+
+import os
+
+# pop off env var set to the old python implementation
+if os.environ.get('PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION', None) == 'python':
+    os.environ.pop('PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION')
+
+try:
+    from google.protobuf.internal import api_implementation
+
+    if (
+        api_implementation.Type() == 'python'
+        and not os.environ.get('CLARIFAI_SKIP_PROTOBUF_CHECK', 'false') == 'true'
+    ):
+        raise Exception(
+            "We do not recommend running this library with the Python implementation of Protocol Buffers. Please check your installation to use the cpp or upb implementation. We recommend setting the environment variable PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=upb. You can skip this check by setting CLARIFAI_SKIP_PROTOBUF_CHECK=true"
+        )
+except ImportError:
+    pass

--- a/clarifai_grpc/__init__.py
+++ b/clarifai_grpc/__init__.py
@@ -1,21 +1,33 @@
 __version__ = "11.7.3"
 
-
 import os
 
 # pop off env var set to the old python implementation
+unset = False
 if os.environ.get('PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION', None) == 'python':
+    unset = True
     os.environ.pop('PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION')
+# Don't use the clarifai logger since it is in the SDK package and depends on protobuf.
+import logging
+
+logger = logging.getLogger(__name__)
+
+if unset:
+    logger.warning(
+        "Unsetting PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python env var while importing clarifai package. It's best to unset this env var in your environemnt for faster performance."
+    )
 
 try:
     from google.protobuf.internal import api_implementation
 
-    if (
-        api_implementation.Type() == 'python'
-        and not os.environ.get('CLARIFAI_SKIP_PROTOBUF_CHECK', 'false') == 'true'
-    ):
-        raise Exception(
-            "We do not recommend running this library with the Python implementation of Protocol Buffers. Please check your installation to use the cpp or upb implementation. We recommend setting the environment variable PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=upb. You can skip this check by setting CLARIFAI_SKIP_PROTOBUF_CHECK=true"
+    if api_implementation.Type() == 'python':
+        logger.warning(
+            "The python version of google protobuf is being used. We recommend that you upgrade the protobuf package >=4.21.0 to use the upd version which is much faster."
         )
+    #     and not os.environ.get('CLARIFAI_SKIP_PROTOBUF_CHECK', 'false') == 'true'
+    # ):
+    #     raise Exception(
+    #         "We do not recommend running this library with the Python implementation of Protocol Buffers. Please check your installation to use the cpp or upb implementation. We recommend setting the environment variable PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=upb. You can skip this check by setting CLARIFAI_SKIP_PROTOBUF_CHECK=true"
+    #     )
 except ImportError:
     pass


### PR DESCRIPTION
If we have `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` with the latest protos from clarifai and latest protobuf (> 4.21.0 atleast) then we get this errors:
```
>>> from clarifai.client.app import App
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.12/dist-packages/clarifai/client/__init__.py", line 1, in <module>
    from clarifai.client.app import App
  File "/usr/local/lib/python3.12/dist-packages/clarifai/client/app.py", line 6, in <module>
    from clarifai_grpc.grpc.api import resources_pb2, service_pb2
  File "/usr/local/lib/python3.12/dist-packages/clarifai_grpc/grpc/api/resources_pb2.py", line 14, in <module>
    from clarifai_grpc.grpc.api.status import status_pb2 as proto_dot_clarifai_dot_api_dot_status_dot_status__pb2
  File "/usr/local/lib/python3.12/dist-packages/clarifai_grpc/grpc/api/status/status_pb2.py", line 14, in <module>
    from clarifai_grpc.grpc.auth.util import extension_pb2 as proto_dot_clarifai_dot_auth_dot_util_dot_extension__pb2
  File "/usr/local/lib/python3.12/dist-packages/clarifai_grpc/grpc/auth/util/extension_pb2.py", line 14, in <module>
    from clarifai_grpc.grpc.auth.scope import scope_pb2 as proto_dot_clarifai_dot_auth_dot_scope_dot_scope__pb2
  File "/usr/local/lib/python3.12/dist-packages/clarifai_grpc/grpc/auth/scope/scope_pb2.py", line 22, in <module>
    google_dot_protobuf_dot_descriptor__pb2.EnumValueOptions.RegisterExtension(clarfai_exposed)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'EnumValueOptions' has no attribute 'RegisterExtension'
```

unsetting that env var if it's python and letting the google protobuf package decide on if it's cpp or upd implementation seems to solve this error in all protobuf versions including the older 3.20.3. 
