### PR TITLE
Bump grpc message size limits.

### DIFF
--- a/clarifai_grpc/__init__.py
+++ b/clarifai_grpc/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "11.7.7"
+__version__ = "11.7.8"
 
 import os
 

--- a/clarifai_grpc/channel/clarifai_channel.py
+++ b/clarifai_grpc/channel/clarifai_channel.py
@@ -6,8 +6,8 @@ import grpc
 from clarifai_grpc.channel.grpc_json_channel import GRPCJSONChannel
 
 RETRIES = 2  # if connections fail retry a couple times.
-CONNECTIONS = 20  # number of connections to maintain in pool.
-MAX_MESSAGE_LENGTH = 128 * 1024 * 1024  # 128MB
+CONNECTIONS = 20  # number of connections to maintain in pool, only usd for json channel, not direct GRPC.
+MAX_MESSAGE_LENGTH = 1024 * 1024 * 1024  # 1GB
 
 wrap_response_deserializer = None
 
@@ -87,6 +87,7 @@ class ClarifaiChannel:
             options=[
                 ("grpc.service_config", grpc_json_config),
                 ("grpc.max_receive_message_length", MAX_MESSAGE_LENGTH),
+                ("grpc.max_send_message_length", MAX_MESSAGE_LENGTH),
             ],
         )
 
@@ -108,6 +109,7 @@ class ClarifaiChannel:
             options=[
                 ("grpc.service_config", grpc_json_config),
                 ("grpc.max_receive_message_length", MAX_MESSAGE_LENGTH),
+                ("grpc.max_send_message_length", MAX_MESSAGE_LENGTH),
             ],
         )
 
@@ -136,6 +138,7 @@ class ClarifaiChannel:
             options=[
                 ("grpc.service_config", grpc_json_config),
                 ("grpc.max_receive_message_length", MAX_MESSAGE_LENGTH),
+                ("grpc.max_send_message_length", MAX_MESSAGE_LENGTH),
             ],
         )
 
@@ -157,5 +160,6 @@ class ClarifaiChannel:
             options=[
                 ("grpc.service_config", grpc_json_config),
                 ("grpc.max_receive_message_length", MAX_MESSAGE_LENGTH),
+                ("grpc.max_send_message_length", MAX_MESSAGE_LENGTH),
             ],
         )


### PR DESCRIPTION
Fix for large batches going to models.

UNKNOWN:Error received from peer  {grpc_message:\"CLIENT: Received message larger than max (437060142 vs. 134217728)