### PR TITLE
Skip tests inside the function instead of Decorators

### DIFF
--- a/tests/client/test_model_crud.py
+++ b/tests/client/test_model_crud.py
@@ -249,12 +249,9 @@ def test_post_model_with_hyper_params(channel_key):
     raise_on_failure(delete_response)
 
 
-@pytest.mark.no_parallel
-@pytest.mark.skip(
-    reason="On Github Actions there's 'Model training had no data' error for some reason"
-)
 @both_channels()
 def test_model_creation_training_and_evaluation(channel_key):
+    pytest.skip("On Github Actions there's 'Model training had no data' error for some reason")
     model_id = str(uuid.uuid4()[:30])
 
     stub = service_pb2_grpc.V2Stub(get_channel(channel_key))

--- a/tests/client/test_model_crud.py
+++ b/tests/client/test_model_crud.py
@@ -249,6 +249,7 @@ def test_post_model_with_hyper_params(channel_key):
     raise_on_failure(delete_response)
 
 
+@pytest.mark.no_parallel
 @pytest.mark.skip(
     reason="On Github Actions there's 'Model training had no data' error for some reason"
 )

--- a/tests/public_models/test_public_models_predicts.py
+++ b/tests/public_models/test_public_models_predicts.py
@@ -205,7 +205,6 @@ async def test_text_predict_on_public_models_async(channel_key, title, model_id,
     )
 
 
-@pytest.mark.skip(reason="This test is ready, but will be added in time")
 @both_channels()
 @pytest.mark.parametrize(
     "title, model_id, text, app_id, user_id ", TEXT_FB_TRANSLATION_MODEL_TITLE_ID_DATA_TUPLE
@@ -217,6 +216,7 @@ def test_text_fb_translation_predict_on_public_models(
     Each language-english translation has its own text input while
     all en-language translations use the same english text.
     """
+    pytest.skip("Skipping test: FB models are currently disabled")
     stub = service_pb2_grpc.V2Stub(get_channel(channel_key))
     request = service_pb2.PostModelOutputsRequest(
         user_app_id=resources_pb2.UserAppIDSet(user_id=user_id, app_id=app_id),


### PR DESCRIPTION
The test test_model_creation_training_and_evaluation is causing failures in Cron runs:
```INTERNALERROR> AssertionError: ('tests/client/test_model_crud.py::test_model_creation_training_and_evaluation[json]', <WorkerController gw1>)```

As a temporary measure, we're skipping the tests within the function body rather than using a decorator.

This is a blind fix, as we suspect the issue may be related to the use of the @skip decorator.