### PR TITLE
[EAGLE-7291] Use PATs for API calls that involve external models

### DIFF
--- a/tests/client/test_annotations_searches.py
+++ b/tests/client/test_annotations_searches.py
@@ -7,6 +7,7 @@ from tests.common import (
     get_channel,
     metadata,
     raise_on_failure,
+    user_app_id,
     wait_for_inputs_upload,
 )
 
@@ -36,6 +37,7 @@ def test_post_annotations_searches(channel_key):
     with SetupImage(stub) as input_:
         post_palm_annotations_response = stub.PostAnnotations(
             service_pb2.PostAnnotationsRequest(
+                user_app_id=user_app_id(),
                 annotations=[
                     resources_pb2.Annotation(
                         input_id=input_.id,
@@ -56,14 +58,16 @@ def test_post_annotations_searches(channel_key):
                             ]
                         ),
                     ),
-                ]
+                ],
             ),
-            metadata=metadata(),
+            # Need PAT to run base workflow with models from clarifai/main against added regions.
+            metadata=metadata(pat=True),
         )
         raise_on_failure(post_palm_annotations_response)
 
         post_water_annotations_response = stub.PostAnnotations(
             service_pb2.PostAnnotationsRequest(
+                user_app_id=user_app_id(),
                 annotations=[
                     resources_pb2.Annotation(
                         input_id=input_.id,
@@ -84,9 +88,10 @@ def test_post_annotations_searches(channel_key):
                             ]
                         ),
                     ),
-                ]
+                ],
             ),
-            metadata=metadata(),
+            # Need PAT to run base workflow with models from clarifai/main against added regions.
+            metadata=metadata(pat=True),
         )
         raise_on_failure(post_water_annotations_response)
 
@@ -186,6 +191,7 @@ class SetupImage:
     def __enter__(self) -> resources_pb2.Input:
         post_response = self._stub.PostInputs(
             service_pb2.PostInputsRequest(
+                user_app_id=user_app_id(),
                 inputs=[
                     resources_pb2.Input(
                         data=resources_pb2.Data(
@@ -194,9 +200,10 @@ class SetupImage:
                             ),
                         ),
                     )
-                ]
+                ],
             ),
-            metadata=metadata(),
+            # Need PAT to run base workflow with models from clarifai/main against added inputs.
+            metadata=metadata(pat=True),
         )
         raise_on_failure(post_response)
         self._input = post_response.inputs[0]

--- a/tests/client/test_dataset_version_export.py
+++ b/tests/client/test_dataset_version_export.py
@@ -16,6 +16,7 @@ from tests.common import (
     metadata,
     raise_on_failure,
     use_secure_hosting_url,
+    user_app_id,
     wait_for_dataset_version_export_success,
     wait_for_dataset_version_ready,
     wait_for_inputs_delete,
@@ -43,6 +44,7 @@ def test_export_dataset_version(channel_key):
 
         post_inputs_response = stub.PostInputs(
             service_pb2.PostInputsRequest(
+                user_app_id=user_app_id(),
                 inputs=[
                     resources_pb2.Input(
                         data=resources_pb2.Data(
@@ -64,7 +66,8 @@ def test_export_dataset_version(channel_key):
                     ),
                 ],
             ),
-            metadata=metadata(),
+            # Need PAT to run base workflow with models from clarifai/main against added inputs.
+            metadata=metadata(pat=True),
         )
         raise_on_failure(post_inputs_response)
 

--- a/tests/client/test_image_crud.py
+++ b/tests/client/test_image_crud.py
@@ -30,7 +30,7 @@ def test_post_list_patch_get_delete_image(channel_key):
                         concepts=[resources_pb2.Concept(id="some-concept")],
                     )
                 )
-            ]
+            ],
         ),
         # Need PAT to run base workflow with models from clarifai/main against added inputs.
         metadata=metadata(pat=True),
@@ -97,7 +97,7 @@ def test_post_delete_batch_images(channel_key):
                         image=resources_pb2.Image(url=TRUCK_IMAGE_URL, allow_duplicate_url=True)
                     )
                 ),
-            ]
+            ],
         ),
         # Need PAT to run base workflow with models from clarifai/main against added inputs.
         metadata=metadata(pat=True),
@@ -146,7 +146,7 @@ def test_post_patch_get_image_with_id_concepts_geo_and_metadata(channel_key):
                         metadata=input_metadata,
                     ),
                 )
-            ]
+            ],
         ),
         # Need PAT to run base workflow with models from clarifai/main against added inputs.
         metadata=metadata(pat=True),
@@ -219,7 +219,7 @@ def test_image_with_bytes(channel_key):
                 resources_pb2.Input(
                     data=resources_pb2.Data(image=resources_pb2.Image(base64=file_bytes))
                 )
-            ]
+            ],
         ),
         # Need PAT to run base workflow with models from clarifai/main against added inputs.
         metadata=metadata(pat=True),

--- a/tests/client/test_image_crud.py
+++ b/tests/client/test_image_crud.py
@@ -11,6 +11,7 @@ from tests.common import (
     get_channel,
     metadata,
     raise_on_failure,
+    user_app_id,
     wait_for_inputs_upload,
 )
 
@@ -21,6 +22,7 @@ def test_post_list_patch_get_delete_image(channel_key):
 
     post_response = stub.PostInputs(
         service_pb2.PostInputsRequest(
+            user_app_id=user_app_id(),
             inputs=[
                 resources_pb2.Input(
                     data=resources_pb2.Data(
@@ -30,7 +32,8 @@ def test_post_list_patch_get_delete_image(channel_key):
                 )
             ]
         ),
-        metadata=metadata(),
+        # Need PAT to run base workflow with models from clarifai/main against added inputs.
+        metadata=metadata(pat=True),
     )
     raise_on_failure(post_response)
     input_id = post_response.inputs[0].id
@@ -82,6 +85,7 @@ def test_post_delete_batch_images(channel_key):
 
     post_response = stub.PostInputs(
         service_pb2.PostInputsRequest(
+            user_app_id=user_app_id(),
             inputs=[
                 resources_pb2.Input(
                     data=resources_pb2.Data(
@@ -95,7 +99,8 @@ def test_post_delete_batch_images(channel_key):
                 ),
             ]
         ),
-        metadata=metadata(),
+        # Need PAT to run base workflow with models from clarifai/main against added inputs.
+        metadata=metadata(pat=True),
     )
     raise_on_failure(post_response)
     input_id1 = post_response.inputs[0].id
@@ -125,6 +130,7 @@ def test_post_patch_get_image_with_id_concepts_geo_and_metadata(channel_key):
 
     post_response = stub.PostInputs(
         service_pb2.PostInputsRequest(
+            user_app_id=user_app_id(),
             inputs=[
                 resources_pb2.Input(
                     id=input_id,
@@ -142,7 +148,8 @@ def test_post_patch_get_image_with_id_concepts_geo_and_metadata(channel_key):
                 )
             ]
         ),
-        metadata=metadata(),
+        # Need PAT to run base workflow with models from clarifai/main against added inputs.
+        metadata=metadata(pat=True),
     )
     raise_on_failure(post_response)
 
@@ -207,13 +214,15 @@ def test_image_with_bytes(channel_key):
 
     post_response = stub.PostInputs(
         service_pb2.PostInputsRequest(
+            user_app_id=user_app_id(),
             inputs=[
                 resources_pb2.Input(
                     data=resources_pb2.Data(image=resources_pb2.Image(base64=file_bytes))
                 )
             ]
         ),
-        metadata=metadata(),
+        # Need PAT to run base workflow with models from clarifai/main against added inputs.
+        metadata=metadata(pat=True),
     )
     raise_on_failure(post_response)
     input_id = post_response.inputs[0].id

--- a/tests/client/test_inputs_searches.py
+++ b/tests/client/test_inputs_searches.py
@@ -22,6 +22,7 @@ from tests.common import (
     get_channel,
     metadata,
     raise_on_failure,
+    user_app_id,
     wait_for_inputs_upload,
 )
 
@@ -408,6 +409,7 @@ class SetupImage:
 
         post_response = self._stub.PostInputs(
             service_pb2.PostInputsRequest(
+                user_app_id=user_app_id(),
                 inputs=[
                     resources_pb2.Input(
                         data=resources_pb2.Data(
@@ -425,7 +427,8 @@ class SetupImage:
                     )
                 ]
             ),
-            metadata=metadata(),
+            # Need PAT to run base workflow with models from clarifai/main against added inputs.
+            metadata=metadata(pat=True),
         )
         raise_on_failure(post_response)
         self._input = post_response.inputs[0]

--- a/tests/client/test_inputs_searches.py
+++ b/tests/client/test_inputs_searches.py
@@ -425,7 +425,7 @@ class SetupImage:
                             ),
                         ),
                     )
-                ]
+                ],
             ),
             # Need PAT to run base workflow with models from clarifai/main against added inputs.
             metadata=metadata(pat=True),

--- a/tests/client/test_model_crud.py
+++ b/tests/client/test_model_crud.py
@@ -11,6 +11,7 @@ from tests.common import (
     get_channel,
     metadata,
     raise_on_failure,
+    user_app_id,
     wait_for_inputs_upload,
     wait_for_model_evaluated,
     wait_for_model_trained,
@@ -68,6 +69,7 @@ def test_post_patch_get_train_evaluate_predict_delete_model(channel_key):
     concept_id_2 = "concept-id-" + uuid.uuid4().hex[:15]
     post_inputs_response = stub.PostInputs(
         service_pb2.PostInputsRequest(
+            user_app_id=user_app_id(),
             inputs=[
                 resources_pb2.Input(
                     data=resources_pb2.Data(
@@ -83,7 +85,8 @@ def test_post_patch_get_train_evaluate_predict_delete_model(channel_key):
                 ),
             ]
         ),
-        metadata=metadata(),
+        # Need PAT to run base workflow with models from clarifai/main against added inputs.
+        metadata=metadata(pat=True),
     )
     raise_on_failure(post_inputs_response)
 

--- a/tests/client/test_model_crud.py
+++ b/tests/client/test_model_crud.py
@@ -83,7 +83,7 @@ def test_post_patch_get_train_evaluate_predict_delete_model(channel_key):
                         concepts=[resources_pb2.Concept(id=concept_id_2)],
                     )
                 ),
-            ]
+            ],
         ),
         # Need PAT to run base workflow with models from clarifai/main against added inputs.
         metadata=metadata(pat=True),

--- a/tests/client/test_secure_data_hosting.py
+++ b/tests/client/test_secure_data_hosting.py
@@ -15,6 +15,7 @@ from tests.common import (
     get_secure_hosting_url,
     raise_on_failure,
     use_secure_hosting_url,
+    user_app_id,
     wait_for_inputs_upload,
 )
 
@@ -22,6 +23,8 @@ DUMMY_KEY = "0" * 32
 PAT = os.environ.get("CLARIFAI_PAT_KEY_SECURE_HOSTING")
 API_KEY = os.environ.get("CLARIFAI_API_KEY_SECURE_HOSTING")
 SESSION_TOKEN = os.environ.get("CLARIFAI_SESSION_TOKEN_SECURE_HOSTING")
+
+USER_APP_ID = user_app_id(app_id=os.environ.get("CLARIFAI_APP_ID_SECURE_HOSTING"))
 
 PAT_CLIENT_AUTH = (("authorization", "Key %s" % PAT),)
 API_CLIENT_AUTH = (("authorization", "Key %s" % API_KEY),)
@@ -152,6 +155,7 @@ def test_adding_inputs(channel_key):
     try:
         post_image_response = stub.PostInputs(
             service_pb2.PostInputsRequest(
+                user_app_id=USER_APP_ID,
                 inputs=[
                     resources_pb2.Input(
                         id=input_img1,
@@ -171,12 +175,14 @@ def test_adding_inputs(channel_key):
                     ),
                 ]
             ),
-            metadata=API_CLIENT_AUTH,
+            # Need PAT to run base workflow with models from clarifai/main against added inputs.
+            metadata=PAT_CLIENT_AUTH,
         )
         raise_on_failure(post_image_response)
 
         post_video_response = stub.PostInputs(  # videos must be uploaded individually
             service_pb2.PostInputsRequest(
+                user_app_id=USER_APP_ID,
                 inputs=[
                     resources_pb2.Input(
                         id=input_vid1,
@@ -188,7 +194,8 @@ def test_adding_inputs(channel_key):
                     )
                 ]
             ),
-            metadata=API_CLIENT_AUTH,
+            # Need PAT to run base workflow with models from clarifai/main against added inputs.
+            metadata=PAT_CLIENT_AUTH,
         )
         raise_on_failure(post_video_response)
 

--- a/tests/client/test_secure_data_hosting.py
+++ b/tests/client/test_secure_data_hosting.py
@@ -173,7 +173,7 @@ def test_adding_inputs(channel_key):
                             ),
                         ),
                     ),
-                ]
+                ],
             ),
             # Need PAT to run base workflow with models from clarifai/main against added inputs.
             metadata=PAT_CLIENT_AUTH,
@@ -192,7 +192,7 @@ def test_adding_inputs(channel_key):
                             ),
                         ),
                     )
-                ]
+                ],
             ),
             # Need PAT to run base workflow with models from clarifai/main against added inputs.
             metadata=PAT_CLIENT_AUTH,

--- a/tests/common.py
+++ b/tests/common.py
@@ -8,7 +8,7 @@ from grpc._channel import _Rendezvous
 
 from clarifai_grpc.channel.clarifai_channel import ClarifaiChannel
 from clarifai_grpc.channel.http_client import CLIENT_VERSION
-from clarifai_grpc.grpc.api import service_pb2, service_pb2_grpc
+from clarifai_grpc.grpc.api import resources_pb2, service_pb2, service_pb2_grpc
 from clarifai_grpc.grpc.api.status import status_code_pb2
 from clarifai_grpc.grpc.api.status.status_pb2 import Status
 
@@ -91,6 +91,12 @@ def metadata(pat: bool = False) -> Tuple[Tuple[str, str], Tuple[str, str]]:
         ("x-clarifai-request-id-prefix", f"python-grpc-{CLIENT_VERSION}"),
         ("authorization", f"Key {key}"),
     )
+
+
+def user_app_id(user_id="me", app_id=None):
+    if app_id is None:
+        app_id = os.environ.get("CLARIFAI_APP_ID")
+    return resources_pb2.UserAppIDSet(user_id=user_id, app_id=app_id)
 
 
 def get_channel(channel_key):


### PR DESCRIPTION
The test applications use the General base workflow which contains public models from clarifai/main. In order to authorize cross-application access, API calls that rely on the base workflow must use a Personal Access Token instead of an application-specific API key.

Update all calls to `PostInputs` and `PostAnnotations` to use a PAT.

Note that `PostInputs` currently does work, but this is planned to change so update the tests now to avoid future breakage.
