### PR TITLE
[EAGLE-7291] Use PATs for API calls that involve external models, part 2

### DIFF
--- a/tests/client/test_input_search_legacy.py
+++ b/tests/client/test_input_search_legacy.py
@@ -12,6 +12,7 @@ from tests.common import (
     get_channel,
     metadata,
     raise_on_failure,
+    user_app_id,
 )
 
 
@@ -180,6 +181,7 @@ def test_search_by_image_url(channel_key):
     with SetupImage(stub) as input_:
         response = stub.PostSearches(
             service_pb2.PostSearchesRequest(
+                user_app_id=user_app_id(),
                 query=resources_pb2.Query(
                     ands=[
                         resources_pb2.And(
@@ -195,7 +197,8 @@ def test_search_by_image_url(channel_key):
                 ),
                 pagination=service_pb2.Pagination(page=1, per_page=1000),
             ),
-            metadata=metadata(),
+            # Need PAT to run embedder model from clarifai/main on the image data.
+            metadata=metadata(pat=True),
         )
         raise_on_failure(response)
         assert len(response.hits) > 0
@@ -210,6 +213,7 @@ def test_search_by_image_bytes(channel_key):
         url_bytes = http_response.read()
         response = stub.PostSearches(
             service_pb2.PostSearchesRequest(
+                user_app_id=user_app_id(),
                 query=resources_pb2.Query(
                     ands=[
                         resources_pb2.And(
@@ -225,7 +229,8 @@ def test_search_by_image_bytes(channel_key):
                 ),
                 pagination=service_pb2.Pagination(page=1, per_page=1000),
             ),
-            metadata=metadata(),
+            # Need PAT to run embedder model from clarifai/main on the image data.
+            metadata=metadata(pat=True),
         )
         raise_on_failure(response)
         assert len(response.hits) > 0
@@ -336,6 +341,7 @@ def test_search_by_image_url_and_geo_box(channel_key):
     with SetupImage(stub) as input_:
         response = stub.PostSearches(
             service_pb2.PostSearchesRequest(
+                user_app_id=user_app_id(),
                 query=resources_pb2.Query(
                     ands=[
                         resources_pb2.And(
@@ -371,7 +377,8 @@ def test_search_by_image_url_and_geo_box(channel_key):
                 ),
                 pagination=service_pb2.Pagination(page=1, per_page=1000),
             ),
-            metadata=metadata(),
+            # Need PAT to run embedder model from clarifai/main on the image data.
+            metadata=metadata(pat=True),
         )
         raise_on_failure(response)
         assert len(response.hits) > 0

--- a/tests/client/test_inputs_searches.py
+++ b/tests/client/test_inputs_searches.py
@@ -181,6 +181,7 @@ def test_search_by_image_url(channel_key):
     with SetupImage(stub) as input_:
         response = stub.PostInputsSearches(
             PostInputsSearchesRequest(
+                user_app_id=user_app_id(),
                 searches=[
                     Search(
                         query=Query(
@@ -196,7 +197,8 @@ def test_search_by_image_url(channel_key):
                 ],
                 pagination=service_pb2.Pagination(page=1, per_page=1000),
             ),
-            metadata=metadata(),
+            # Need PAT to run embedder model from clarifai/main on the image data.
+            metadata=metadata(pat=True),
         )
         raise_on_failure(response)
         assert len(response.hits) >= 1
@@ -213,6 +215,7 @@ def test_search_by_image_bytes(channel_key):
     with SetupImage(stub) as input_:
         response = stub.PostInputsSearches(
             PostInputsSearchesRequest(
+                user_app_id=user_app_id(),
                 searches=[
                     Search(
                         query=Query(
@@ -226,7 +229,8 @@ def test_search_by_image_bytes(channel_key):
                 ],
                 pagination=service_pb2.Pagination(page=1, per_page=1000),
             ),
-            metadata=metadata(),
+            # Need PAT to run embedder model from clarifai/main on the image data.
+            metadata=metadata(pat=True),
         )
         raise_on_failure(response)
         assert len(response.hits) >= 1
@@ -350,6 +354,7 @@ def test_search_by_image_url_and_geo_box(channel_key):
     with SetupImage(stub) as input_:
         response = stub.PostInputsSearches(
             PostInputsSearchesRequest(
+                user_app_id=user_app_id(),
                 searches=[
                     Search(
                         query=Query(
@@ -387,7 +392,8 @@ def test_search_by_image_url_and_geo_box(channel_key):
                 ],
                 pagination=service_pb2.Pagination(page=1, per_page=1000),
             ),
-            metadata=metadata(),
+            # Need PAT to run embedder model from clarifai/main on the image data.
+            metadata=metadata(pat=True),
         )
         raise_on_failure(response)
         assert len(response.hits) >= 1

--- a/tests/client/test_model_crud.py
+++ b/tests/client/test_model_crud.py
@@ -169,6 +169,7 @@ def test_post_patch_get_train_evaluate_predict_delete_model(channel_key):
 
         post_model_outputs_response = stub.PostModelOutputs(
             service_pb2.PostModelOutputsRequest(
+                user_app_id=user_app_id(),
                 model_id=model_id,
                 version_id=model_version_id,
                 inputs=[
@@ -177,7 +178,8 @@ def test_post_patch_get_train_evaluate_predict_delete_model(channel_key):
                     )
                 ],
             ),
-            metadata=metadata(),
+            # Need PAT to run embedder model from clarifai/main on the image data.
+            metadata=metadata(pat=True),
         )
         raise_on_failure(post_model_outputs_response)
         assert len(post_model_outputs_response.outputs) == 1


### PR DESCRIPTION
Search and custom predict operations with an image input use the embedder model from the base workflow of the application. The test applications use the general-image-embedding model from clarifai/main, so they need to use a Personal Access Token to access the model from another application.

* Update all search calls that rank by embeddings (image data) to use a PAT.
* Update predict calls to embedding-classifier models to use a PAT.
