### PR TITLE
chore(deps): upgrade pytest 8.3.5 → 9.0.3 and requests 2.31.0 -> 2.33.0

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10"]
+        python-version: ["3.8", "3.9"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.10"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,7 @@
-pytest==9.0.3
-pytest-xdist==3.6.1
+pytest==8.3.5; python_version<'3.10'
+pytest-xdist==2.2.1; python_version<'3.10'
+pytest==9.0.3; python_version>='3.10'
+pytest-xdist==3.6.1; python_version>='3.10'
 pytest-asyncio>=0.24.0
 requests==2.33.0
 openai==1.86.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
-pytest==8.3.5
-pytest-xdist==2.2.1
+pytest==9.0.3
+pytest-xdist==3.6.1
 pytest-asyncio>=0.24.0
-requests==2.31.0
+requests==2.33.0
 openai==1.86.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,5 +3,6 @@ pytest-xdist==2.2.1; python_version<'3.10'
 pytest==9.0.3; python_version>='3.10'
 pytest-xdist==3.6.1; python_version>='3.10'
 pytest-asyncio>=0.24.0
-requests==2.33.0
+requests==2.31.0; python_version<'3.10'
+requests==2.33.0; python_version>='3.10'
 openai==1.86.0


### PR DESCRIPTION
## Summary
Resolves Dependabot alert by upgrading `pytest` from `8.3.5` to `9.0.3` along with `requests` from `2.31.0` to `2.33.0`

---

## Dependency Changes (`requirements.txt`)

| Package | Old Version | New Version | Reason |
|---|---|---|---|
| `pytest` | `8.3.5` | `9.0.3` | Dependabot alert / security & feature upgrade |
| `pytest-xdist` | `2.2.1` | `3.6.1` | Updated for full pytest 9 compatibility |
| `requests` | `2.31.1` | `2.33.0` | Dependabot alert / security & feature upgrade |

## Alerts

- https://github.com/Clarifai/clarifai-python-grpc/security/dependabot/24
- https://github.com/Clarifai/clarifai-python-grpc/security/dependabot/11
- https://github.com/Clarifai/clarifai-python-grpc/security/dependabot/12
- https://github.com/Clarifai/clarifai-python-grpc/security/dependabot/23